### PR TITLE
stability: split SessionCoordinator title/meta/activity helpers

### DIFF
--- a/core/session-activity.ts
+++ b/core/session-activity.ts
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+
+type AnyRecord = Record<string, any>;
+type AgentLike = AnyRecord;
+
+export function promoteActivitySessionFile(activitySessionFile: string, agent: AgentLike, opts: {
+  onPromoted?: (activitySessionFile: string, newPath: string) => void;
+  onError?: (err: unknown) => void;
+} = {}) {
+  const oldPath = path.join(agent.agentDir, "activity", activitySessionFile);
+  if (!fs.existsSync(oldPath)) return null;
+
+  const newPath = path.join(agent.sessionDir, activitySessionFile);
+  try {
+    fs.renameSync(oldPath, newPath);
+    agent._memoryTicker?.notifyPromoted(newPath);
+    opts.onPromoted?.(activitySessionFile, newPath);
+    return newPath;
+  } catch (err) {
+    opts.onError?.(err);
+    return null;
+  }
+}

--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -78,6 +78,13 @@ import {
   formatRelaySummaryContext,
   resolveSessionRelayConfig,
 } from "./session-relay.js";
+import { promoteActivitySessionFile } from "./session-activity.js";
+import {
+  loadSessionTitlesFor,
+  saveSessionMetaFile,
+  saveSessionTitleFile,
+  type SessionTitleCacheEntry,
+} from "./session-title-meta.js";
 import type { ResolvedModel } from "./types.js";
 
 const log = createModuleLogger("session");
@@ -128,7 +135,6 @@ type SessionCoordinatorDeps = AnyRecord & {
   getAgentById: (agentId: string) => AgentLike | null | undefined;
   listAgents: () => AgentLike[];
 };
-type SessionTitleCacheEntry = { titles: Record<string, string>; ts: number };
 type IsolatedExecutionOptions = AnyRecord & {
   agentId?: string;
   signal?: AbortSignal;
@@ -226,8 +232,6 @@ export class SessionCoordinator {
     this._pendingPlanMode = false;
     this._pendingSecurityMode = DEFAULT_SECURITY_MODE;
   }
-
-  static _TITLES_TTL = 60_000; // 60 秒
 
   get session() { return this._session; }
   get sessionStarted() { return this._sessionStarted; }
@@ -1239,44 +1243,24 @@ export class SessionCoordinator {
   }
 
   async saveSessionTitle(sessionPath: string, title: string) {
-    const agentId = this._d.agentIdFromSessionPath(sessionPath);
-    const sessionDir = agentId
-      ? path.join(this._d.agentsDir, agentId, "sessions")
-      : this._d.getAgent().sessionDir;
-    const titlePath = path.join(sessionDir, "session-titles.json");
-    const titles = await this._loadSessionTitlesFor(sessionDir);
-    titles[sessionPath] = title;
-    await fsp.writeFile(titlePath, JSON.stringify(titles, null, 2), "utf-8");
-    // 更新缓存
-    this._titlesCache.set(sessionDir, { titles: { ...titles }, ts: Date.now() });
+    await saveSessionTitleFile(sessionPath, title, {
+      agentsDir: this._d.agentsDir,
+      currentAgent: this._d.getAgent(),
+      agentIdFromSessionPath: this._d.agentIdFromSessionPath,
+      titlesCache: this._titlesCache,
+    });
   }
 
   async saveSessionMeta(sessionPath: string, meta: AnyRecord) {
-    const agentId = this._d.agentIdFromSessionPath(sessionPath);
-    const sessionDir = agentId
-      ? path.join(this._d.agentsDir, agentId, "sessions")
-      : this._d.getAgent().sessionDir;
-    const metaPath = path.join(sessionDir, "session-meta.json");
-    let allMeta: Record<string, AnyRecord> = {};
-    try { allMeta = JSON.parse(await fsp.readFile(metaPath, "utf-8")); } catch {}
-    allMeta[sessionPath] = { ...(allMeta[sessionPath] || {}), ...meta };
-    await fsp.writeFile(metaPath, JSON.stringify(allMeta, null, 2), "utf-8");
+    await saveSessionMetaFile(sessionPath, meta, {
+      agentsDir: this._d.agentsDir,
+      currentAgent: this._d.getAgent(),
+      agentIdFromSessionPath: this._d.agentIdFromSessionPath,
+    });
   }
 
   async _loadSessionTitlesFor(sessionDir: string): Promise<Record<string, string>> {
-    const cached = this._titlesCache.get(sessionDir);
-    if (cached && Date.now() - cached.ts < SessionCoordinator._TITLES_TTL) {
-      return { ...cached.titles };
-    }
-    try {
-      const raw = await fsp.readFile(path.join(sessionDir, "session-titles.json"), "utf-8");
-      const titles = JSON.parse(raw);
-      this._titlesCache.set(sessionDir, { titles, ts: Date.now() });
-      return { ...titles };
-    } catch {
-      this._titlesCache.set(sessionDir, { titles: {}, ts: Date.now() });
-      return {};
-    }
+    return loadSessionTitlesFor(sessionDir, this._titlesCache);
   }
 
   // ── Session Context ──
@@ -1340,20 +1324,10 @@ export class SessionCoordinator {
   }
 
   promoteActivitySession(activitySessionFile: string) {
-    const agent = this._d.getAgent();
-    const oldPath = path.join(agent.agentDir, "activity", activitySessionFile);
-    if (!fs.existsSync(oldPath)) return null;
-
-    const newPath = path.join(agent.sessionDir, activitySessionFile);
-    try {
-      fs.renameSync(oldPath, newPath);
-      agent._memoryTicker?.notifyPromoted(newPath);
-      log.log(`promoted activity session: ${activitySessionFile}`);
-      return newPath;
-    } catch (err) {
-      log.error(`promoteActivitySession failed: ${errMessage(err)}`);
-      return null;
-    }
+    return promoteActivitySessionFile(activitySessionFile, this._d.getAgent(), {
+      onPromoted: () => log.log(`promoted activity session: ${activitySessionFile}`),
+      onError: (err) => log.error(`promoteActivitySession failed: ${errMessage(err)}`),
+    });
   }
 
   // ── Isolated Execution ──

--- a/core/session-title-meta.ts
+++ b/core/session-title-meta.ts
@@ -1,0 +1,69 @@
+import fsp from "fs/promises";
+import path from "path";
+
+type AnyRecord = Record<string, any>;
+type AgentLike = AnyRecord;
+
+export type SessionTitleCacheEntry = { titles: Record<string, string>; ts: number };
+
+const SESSION_TITLES_TTL_MS = 60_000;
+
+export function resolveSessionDirForPath(sessionPath: string, opts: {
+  agentsDir: string;
+  currentAgent: AgentLike;
+  agentIdFromSessionPath: (sessionPath: string) => string | null | undefined;
+}) {
+  const agentId = opts.agentIdFromSessionPath(sessionPath);
+  return agentId
+    ? path.join(opts.agentsDir, agentId, "sessions")
+    : opts.currentAgent.sessionDir;
+}
+
+export async function loadSessionTitlesFor(
+  sessionDir: string,
+  titlesCache: Map<string, SessionTitleCacheEntry>,
+  ttlMs = SESSION_TITLES_TTL_MS,
+) {
+  const cached = titlesCache.get(sessionDir);
+  if (cached && Date.now() - cached.ts < ttlMs) {
+    return { ...cached.titles };
+  }
+  try {
+    const raw = await fsp.readFile(path.join(sessionDir, "session-titles.json"), "utf-8");
+    const titles = JSON.parse(raw);
+    titlesCache.set(sessionDir, { titles, ts: Date.now() });
+    return { ...titles };
+  } catch {
+    titlesCache.set(sessionDir, { titles: {}, ts: Date.now() });
+    return {};
+  }
+}
+
+export async function saveSessionTitleFile(sessionPath: string, title: string, opts: {
+  agentsDir: string;
+  currentAgent: AgentLike;
+  agentIdFromSessionPath: (sessionPath: string) => string | null | undefined;
+  titlesCache: Map<string, SessionTitleCacheEntry>;
+}) {
+  const sessionDir = resolveSessionDirForPath(sessionPath, opts);
+  const titlePath = path.join(sessionDir, "session-titles.json");
+  const titles = await loadSessionTitlesFor(sessionDir, opts.titlesCache);
+  titles[sessionPath] = title;
+  await fsp.writeFile(titlePath, JSON.stringify(titles, null, 2), "utf-8");
+  opts.titlesCache.set(sessionDir, { titles: { ...titles }, ts: Date.now() });
+}
+
+export async function saveSessionMetaFile(sessionPath: string, meta: AnyRecord, opts: {
+  agentsDir: string;
+  currentAgent: AgentLike;
+  agentIdFromSessionPath: (sessionPath: string) => string | null | undefined;
+}) {
+  const sessionDir = resolveSessionDirForPath(sessionPath, opts);
+  const metaPath = path.join(sessionDir, "session-meta.json");
+  let allMeta: Record<string, AnyRecord> = {};
+  try {
+    allMeta = JSON.parse(await fsp.readFile(metaPath, "utf-8"));
+  } catch {}
+  allMeta[sessionPath] = { ...(allMeta[sessionPath] || {}), ...meta };
+  await fsp.writeFile(metaPath, JSON.stringify(allMeta, null, 2), "utf-8");
+}

--- a/tests/session-activity.test.js
+++ b/tests/session-activity.test.js
@@ -1,0 +1,47 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { promoteActivitySessionFile } from "../core/session-activity.js";
+
+describe("session activity helpers", () => {
+  const dirs = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function tempAgent() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "lynn-session-activity-"));
+    dirs.push(root);
+    const agentDir = path.join(root, "agent");
+    const activityDir = path.join(agentDir, "activity");
+    const sessionDir = path.join(agentDir, "sessions");
+    fs.mkdirSync(activityDir, { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    return { agentDir, activityDir, sessionDir };
+  }
+
+  it("promotes an activity session into normal sessions and notifies memory", () => {
+    const agent = tempAgent();
+    const notifyPromoted = vi.fn();
+    fs.writeFileSync(path.join(agent.activityDir, "a.jsonl"), "{}\n");
+
+    const result = promoteActivitySessionFile("a.jsonl", {
+      ...agent,
+      _memoryTicker: { notifyPromoted },
+    });
+
+    expect(result).toBe(path.join(agent.sessionDir, "a.jsonl"));
+    expect(fs.existsSync(path.join(agent.activityDir, "a.jsonl"))).toBe(false);
+    expect(fs.existsSync(path.join(agent.sessionDir, "a.jsonl"))).toBe(true);
+    expect(notifyPromoted).toHaveBeenCalledWith(path.join(agent.sessionDir, "a.jsonl"));
+  });
+
+  it("returns null when the activity session does not exist", () => {
+    const agent = tempAgent();
+    expect(promoteActivitySessionFile("missing.jsonl", agent)).toBe(null);
+  });
+});

--- a/tests/session-title-meta.test.js
+++ b/tests/session-title-meta.test.js
@@ -1,0 +1,71 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  loadSessionTitlesFor,
+  saveSessionMetaFile,
+  saveSessionTitleFile,
+} from "../core/session-title-meta.js";
+
+describe("session title/meta helpers", () => {
+  const dirs = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function tempAgent() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "lynn-session-title-meta-"));
+    dirs.push(root);
+    const agentsDir = path.join(root, "agents");
+    const sessionDir = path.join(agentsDir, "agent-a", "sessions");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    return {
+      root,
+      agentsDir,
+      sessionDir,
+      currentAgent: { id: "agent-a", sessionDir },
+      agentIdFromSessionPath: () => "agent-a",
+    };
+  }
+
+  it("loads titles through a copy-on-read cache", async () => {
+    const agent = tempAgent();
+    fs.writeFileSync(path.join(agent.sessionDir, "session-titles.json"), JSON.stringify({ a: "Alpha" }));
+    const cache = new Map();
+
+    const first = await loadSessionTitlesFor(agent.sessionDir, cache);
+    first.a = "Mutated";
+    const second = await loadSessionTitlesFor(agent.sessionDir, cache);
+
+    expect(second).toEqual({ a: "Alpha" });
+  });
+
+  it("writes session titles and refreshes the title cache", async () => {
+    const agent = tempAgent();
+    const cache = new Map();
+    const sessionPath = path.join(agent.sessionDir, "a.jsonl");
+
+    await saveSessionTitleFile(sessionPath, "New Title", { ...agent, titlesCache: cache });
+
+    const raw = JSON.parse(fs.readFileSync(path.join(agent.sessionDir, "session-titles.json"), "utf-8"));
+    expect(raw[sessionPath]).toBe("New Title");
+    expect(cache.get(agent.sessionDir).titles[sessionPath]).toBe("New Title");
+  });
+
+  it("merges session meta without dropping existing fields", async () => {
+    const agent = tempAgent();
+    const sessionPath = path.join(agent.sessionDir, "a.jsonl");
+    fs.writeFileSync(path.join(agent.sessionDir, "session-meta.json"), JSON.stringify({
+      [sessionPath]: { memoryEnabled: true, modelId: "old" },
+    }));
+
+    await saveSessionMetaFile(sessionPath, { modelId: "new" }, agent);
+
+    const raw = JSON.parse(fs.readFileSync(path.join(agent.sessionDir, "session-meta.json"), "utf-8"));
+    expect(raw[sessionPath]).toEqual({ memoryEnabled: true, modelId: "new" });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract session title cache reads/writes and session meta merge writes into `core/session-title-meta.ts`.
- Extract activity-session promotion file movement into `core/session-activity.ts`.
- Add focused helper tests for title cache copy-on-read, metadata merging, and activity promotion.

## Validation
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npx vitest run tests/session-title-meta.test.js tests/session-activity.test.js tests/session-coordinator.test.js tests/session-index.test.js tests/session-list-cache.test.js tests/session-relay.test.js --reporter=dot`
- `npm run release:gate`

No model assets were downloaded locally.