### PR TITLE
stability: split SessionCoordinator dry-run helpers

### DIFF
--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -6,10 +6,7 @@
  * 不持有 engine 引用，通过构造器注入依赖。
  */
 import fs from "fs";
-import fsp from "fs/promises";
-import os from "os";
 import path from "path";
-import { spawnSync } from "child_process";
 import {
   createAgentSession,
   SessionManager,
@@ -85,6 +82,10 @@ import {
   saveSessionTitleFile,
   type SessionTitleCacheEntry,
 } from "./session-title-meta.js";
+import {
+  prepareDryRunWorkspace,
+  runDryRunValidation,
+} from "./session-dry-run.js";
 import type { ResolvedModel } from "./types.js";
 
 const log = createModuleLogger("session");
@@ -175,19 +176,6 @@ export const PATROL_TOOLS_DEFAULT = [
   "todo", "notify",
   "present_files", "message_agent",
 ];
-
-const DRY_RUN_COPY_IGNORES = new Set([
-  ".git",
-  "node_modules",
-  ".next",
-  "dist",
-  "build",
-  ".turbo",
-  ".cache",
-  ".venv",
-  "venv",
-  "__pycache__",
-]);
 
 export class SessionCoordinator {
   _d: SessionCoordinatorDeps;
@@ -1602,36 +1590,10 @@ export class SessionCoordinator {
   }
 
   async _prepareDryRunWorkspace(sourceDir: string) {
-    const src = path.resolve(sourceDir || process.cwd());
-    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lynn-shadow-"));
-    await fsp.cp(src, tempDir, {
-      recursive: true,
-      dereference: false,
-      filter: (itemPath) => {
-        const base = path.basename(itemPath);
-        if (itemPath === src) return true;
-        return !DRY_RUN_COPY_IGNORES.has(base);
-      },
-    });
-    return tempDir;
+    return prepareDryRunWorkspace(sourceDir);
   }
 
   _runDryRunValidation(cwd: string, validateCommand: unknown[] | undefined) {
-    if (!Array.isArray(validateCommand) || validateCommand.length === 0) return null;
-    const [command, ...args] = validateCommand.map((item) => String(item));
-    if (!command) return null;
-    const result = spawnSync(command, args, {
-      cwd,
-      encoding: "utf-8",
-      maxBuffer: 1024 * 1024,
-    });
-    return {
-      command,
-      args,
-      exitCode: result.status ?? 0,
-      signal: result.signal || null,
-      stdout: (result.stdout || "").trim().slice(0, 4000),
-      stderr: (result.stderr || "").trim().slice(0, 4000),
-    };
+    return runDryRunValidation(cwd, validateCommand);
   }
 }

--- a/core/session-dry-run.ts
+++ b/core/session-dry-run.ts
@@ -1,0 +1,51 @@
+import { spawnSync } from "child_process";
+import fsp from "fs/promises";
+import os from "os";
+import path from "path";
+
+const DRY_RUN_COPY_IGNORES = new Set([
+  ".git",
+  "node_modules",
+  ".next",
+  "dist",
+  "build",
+  ".turbo",
+  ".cache",
+  ".venv",
+  "venv",
+  "__pycache__",
+]);
+
+export async function prepareDryRunWorkspace(sourceDir: string) {
+  const src = path.resolve(sourceDir || process.cwd());
+  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lynn-shadow-"));
+  await fsp.cp(src, tempDir, {
+    recursive: true,
+    dereference: false,
+    filter: (itemPath) => {
+      const base = path.basename(itemPath);
+      if (itemPath === src) return true;
+      return !DRY_RUN_COPY_IGNORES.has(base);
+    },
+  });
+  return tempDir;
+}
+
+export function runDryRunValidation(cwd: string, validateCommand: unknown[] | undefined) {
+  if (!Array.isArray(validateCommand) || validateCommand.length === 0) return null;
+  const [command, ...args] = validateCommand.map((item) => String(item));
+  if (!command) return null;
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf-8",
+    maxBuffer: 1024 * 1024,
+  });
+  return {
+    command,
+    args,
+    exitCode: result.status ?? 0,
+    signal: result.signal || null,
+    stdout: (result.stdout || "").trim().slice(0, 4000),
+    stderr: (result.stderr || "").trim().slice(0, 4000),
+  };
+}

--- a/tests/session-dry-run.test.js
+++ b/tests/session-dry-run.test.js
@@ -1,0 +1,64 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  prepareDryRunWorkspace,
+  runDryRunValidation,
+} from "../core/session-dry-run.js";
+
+describe("session dry-run helpers", () => {
+  const dirs = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function tempDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lynn-session-dry-run-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  it("copies a shadow workspace while skipping heavy generated directories", async () => {
+    const source = tempDir();
+    fs.writeFileSync(path.join(source, "keep.txt"), "ok");
+    fs.mkdirSync(path.join(source, "node_modules"));
+    fs.writeFileSync(path.join(source, "node_modules", "skip.txt"), "nope");
+    fs.mkdirSync(path.join(source, ".git"));
+    fs.writeFileSync(path.join(source, ".git", "config"), "nope");
+
+    const shadow = await prepareDryRunWorkspace(source);
+    dirs.push(shadow);
+
+    expect(shadow).not.toBe(source);
+    expect(fs.readFileSync(path.join(shadow, "keep.txt"), "utf-8")).toBe("ok");
+    expect(fs.existsSync(path.join(shadow, "node_modules"))).toBe(false);
+    expect(fs.existsSync(path.join(shadow, ".git"))).toBe(false);
+  });
+
+  it("runs validation commands and trims captured output", () => {
+    const cwd = tempDir();
+    const result = runDryRunValidation(cwd, [
+      process.execPath,
+      "-e",
+      "console.log('valid'); console.error('warn')",
+    ]);
+
+    expect(result).toMatchObject({
+      command: process.execPath,
+      args: ["-e", "console.log('valid'); console.error('warn')"],
+      exitCode: 0,
+      signal: null,
+      stdout: "valid",
+      stderr: "warn",
+    });
+  });
+
+  it("ignores missing validation commands", () => {
+    expect(runDryRunValidation(tempDir(), undefined)).toBe(null);
+    expect(runDryRunValidation(tempDir(), [])).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract dry-run shadow workspace preparation into `core/session-dry-run.ts`.
- Extract dry-run validation command execution into the same helper module.
- Add focused tests for ignored generated directories and validation output capture.

## Validation
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npx vitest run tests/session-dry-run.test.js tests/session-coordinator.test.js --reporter=dot`
- `npm run release:gate`

No model assets were downloaded locally.