### PR TITLE
stability: split SessionCoordinator isolated runtime helpers

### DIFF
--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -86,7 +86,13 @@ import {
   prepareDryRunWorkspace,
   runDryRunValidation,
 } from "./session-dry-run.js";
+import {
+  prepareIsolatedToolRuntime,
+  resolveIsolatedExecutionModel,
+} from "./session-isolated-runtime.js";
 import type { ResolvedModel } from "./types.js";
+
+export { PATROL_TOOLS_DEFAULT } from "./session-isolated-runtime.js";
 
 const log = createModuleLogger("session");
 
@@ -167,15 +173,6 @@ function shouldExposeVerboseModelRouting() {
   const flag = String(process?.env?.LYNN_DEBUG_MODELS || process?.env?.DEBUG_MODEL_ROUTING || "").trim().toLowerCase();
   return flag === "1" || flag === "true" || process?.env?.NODE_ENV === "development";
 }
-
-/** 巡检/定时任务默认工具白名单 */
-export const PATROL_TOOLS_DEFAULT = [
-  "search_memory", "pin_memory", "unpin_memory",
-  "recall_experience", "record_experience",
-  "web_search", "web_fetch",
-  "todo", "notify",
-  "present_files", "message_agent",
-];
 
 export class SessionCoordinator {
   _d: SessionCoordinatorDeps;
@@ -1351,63 +1348,32 @@ export class SessionCoordinator {
       }
       const execCwd = dryRunWorkspace || baseExecCwd;
       const models = this._d.getModels();
-      const agentPreferredRef = targetAgent.config?.models?.chat;
-      const modelId = opts.model ? null
-        : (typeof agentPreferredRef === "object" ? agentPreferredRef?.id : agentPreferredRef);
-      const modelProvider = opts.model ? undefined
-        : (typeof agentPreferredRef === "object" ? agentPreferredRef?.provider : undefined);
-      let resolvedModel = opts.model;
+      const resolved = resolveIsolatedExecutionModel({
+        explicitModel: opts.model,
+        targetAgent,
+        availableModels: models.availableModels,
+        defaultModel: models.defaultModel,
+      });
+      const resolvedModel = resolved.model;
       if (!resolvedModel) {
-        const targetRole = targetAgent.config?.agent?.yuan || targetAgent.yuan || null;
-        if (modelId) {
-          resolvedModel = findModel(models.availableModels, modelId, modelProvider) as ModelLike;
-        }
-        if (!resolvedModel) {
-          resolvedModel = resolveRoleDefaultModel(models.availableModels, targetRole) as ModelLike;
-        }
-        if (!resolvedModel) {
-          // agent 未配 models.chat 或配置的模型不在可用列表：fallback 到当前默认模型
-          resolvedModel = models.defaultModel;
-        }
-        if (!resolvedModel) {
-          log.error(`[executeIsolated] agent "${targetAgent.agentName}" 未指定 models.chat，也没有可用的默认模型`);
-          throw new Error(t("error.executeIsolatedNoModel", { name: targetAgent.agentName }));
-        }
-        if (modelId && resolvedModel.id !== modelId) {
-          log.log(`[executeIsolated] 模型 "${modelId}" 不可用，fallback → ${resolvedModel.id}`);
-        }
+        log.error(`[executeIsolated] agent "${targetAgent.agentName}" 未指定 models.chat，也没有可用的默认模型`);
+        throw new Error(t("error.executeIsolatedNoModel", { name: targetAgent.agentName }));
+      }
+      if (resolved.usedFallback && resolved.requestedModelId) {
+        log.log(`[executeIsolated] 模型 "${resolved.requestedModelId}" 不可用，fallback → ${resolvedModel.id}`);
       }
       const execModel = models.resolveExecutionModel(resolvedModel);
       tempSessionMgr = SessionManager.create(execCwd, sessionDir);
-      const { tools: allBuiltinTools, customTools: allCustomTools } = this._d.buildTools(
+      const isolatedTools = prepareIsolatedToolRuntime({
         execCwd,
-        targetAgent.tools,
-        {
-          agentDir: targetAgent.agentDir,
-          workspace: execCwd,
-          getSessionPath: () => tempSessionMgr?.getSessionFile?.() || null,
-        }
-      );
-
-      const patrolAllowed = opts.toolFilter
-        || targetAgent.config?.desk?.patrol_tools
-        || PATROL_TOOLS_DEFAULT;
-      const allowSet = new Set(patrolAllowed);
-      const suppressClientTools = shouldSuppressClientToolSchema(execModel);
-      const actCustomTools = suppressClientTools
-        ? []
-        : normalizeCustomToolsForModel(
-            allCustomTools.filter((t: ToolLike) => allowSet.has(t.name)),
-            execModel
-          );
-
-      // builtin tools 过滤：传入 builtinFilter 时只保留白名单内的 builtin 工具
-      const actTools = suppressClientTools
-        ? []
-        : (opts.builtinFilter
-            ? allBuiltinTools.filter((t: ToolLike) => opts.builtinFilter?.includes(t.name))
-            : allBuiltinTools);
-      if (suppressClientTools) {
+        targetAgent,
+        execModel,
+        buildTools: this._d.buildTools,
+        getSessionPath: () => tempSessionMgr?.getSessionFile?.() || null,
+        toolFilter: opts.toolFilter,
+        builtinFilter: opts.builtinFilter,
+      });
+      if (isolatedTools.suppressClientTools) {
         log.log(`[executeIsolated] using Brain V2 internal tool chain for ${execModel?.provider || "?"}/${execModel?.id || execModel?.name || "?"}; client tool schema suppressed`);
       }
 
@@ -1436,8 +1402,8 @@ export class SessionCoordinator {
         model: execModel,
         thinkingLevel: models.resolveThinkingLevel(this._d.getPrefs().getThinkingLevel(), execModel),
         resourceLoader: execResourceLoader,
-        tools: actTools,
-        customTools: actCustomTools,
+        tools: isolatedTools.tools,
+        customTools: isolatedTools.customTools,
         ...(Object.keys(clientAgentHeaders).length > 0 && { requestHeaders: clientAgentHeaders }),
         ...(clientAgentMetadata && { requestMetadata: clientAgentMetadata }),
       } as any);

--- a/core/session-isolated-runtime.ts
+++ b/core/session-isolated-runtime.ts
@@ -1,0 +1,106 @@
+import { findModel } from "../shared/model-ref.js";
+import { resolveRoleDefaultModel } from "../shared/assistant-role-models.js";
+import {
+  normalizeCustomToolsForModel,
+  shouldSuppressClientToolSchema,
+  type ToolLike,
+} from "./session-tool-runtime.js";
+import type { ResolvedModel } from "./types.js";
+
+type AnyRecord = Record<string, any>;
+type AgentLike = AnyRecord;
+type AvailableModelLike = AnyRecord & { id: string; provider?: string | null };
+type ModelLike = ResolvedModel | AnyRecord | null;
+
+/** 巡检/定时任务默认工具白名单 */
+export const PATROL_TOOLS_DEFAULT = [
+  "search_memory", "pin_memory", "unpin_memory",
+  "recall_experience", "record_experience",
+  "web_search", "web_fetch",
+  "todo", "notify",
+  "present_files", "message_agent",
+];
+
+export function resolveIsolatedExecutionModel(opts: {
+  explicitModel?: ModelLike;
+  targetAgent: AgentLike;
+  availableModels: AvailableModelLike[];
+  defaultModel?: ModelLike;
+}) {
+  if (opts.explicitModel) {
+    return {
+      model: opts.explicitModel,
+      requestedModelId: null,
+      usedFallback: false,
+    };
+  }
+
+  const agentPreferredRef = opts.targetAgent.config?.models?.chat;
+  const requestedModelId = typeof agentPreferredRef === "object"
+    ? agentPreferredRef?.id
+    : agentPreferredRef;
+  const requestedModelProvider = typeof agentPreferredRef === "object"
+    ? agentPreferredRef?.provider
+    : undefined;
+  const targetRole = opts.targetAgent.config?.agent?.yuan || opts.targetAgent.yuan || null;
+
+  let model = requestedModelId
+    ? findModel(opts.availableModels, requestedModelId, requestedModelProvider) as ModelLike
+    : null;
+  if (!model) {
+    model = resolveRoleDefaultModel(opts.availableModels, targetRole) as ModelLike;
+  }
+  if (!model) {
+    model = opts.defaultModel || null;
+  }
+
+  return {
+    model,
+    requestedModelId: requestedModelId || null,
+    usedFallback: !!(requestedModelId && model && model.id !== requestedModelId),
+  };
+}
+
+export function prepareIsolatedToolRuntime(opts: {
+  execCwd: string;
+  targetAgent: AgentLike;
+  execModel: ModelLike;
+  buildTools: (cwd: string, customTools?: unknown, buildOpts?: AnyRecord) => { tools: ToolLike[]; customTools: ToolLike[] };
+  getSessionPath: () => string | null;
+  toolFilter?: string[];
+  builtinFilter?: string[];
+}) {
+  const { tools: allBuiltinTools, customTools: allCustomTools } = opts.buildTools(
+    opts.execCwd,
+    opts.targetAgent.tools,
+    {
+      agentDir: opts.targetAgent.agentDir,
+      workspace: opts.execCwd,
+      getSessionPath: opts.getSessionPath,
+    },
+  );
+
+  const patrolAllowed = opts.toolFilter
+    || opts.targetAgent.config?.desk?.patrol_tools
+    || PATROL_TOOLS_DEFAULT;
+  const allowSet = new Set(patrolAllowed);
+  const suppressClientTools = shouldSuppressClientToolSchema(opts.execModel);
+  const actCustomTools = suppressClientTools
+    ? []
+    : normalizeCustomToolsForModel(
+        allCustomTools.filter((tool: ToolLike) => allowSet.has(tool.name)),
+        opts.execModel,
+      );
+
+  const actTools = suppressClientTools
+    ? []
+    : (opts.builtinFilter
+        ? allBuiltinTools.filter((tool: ToolLike) => opts.builtinFilter?.includes(tool.name))
+        : allBuiltinTools);
+
+  return {
+    tools: actTools,
+    customTools: actCustomTools,
+    suppressClientTools,
+  };
+}

--- a/tests/session-isolated-runtime.test.js
+++ b/tests/session-isolated-runtime.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  PATROL_TOOLS_DEFAULT,
+  prepareIsolatedToolRuntime,
+  resolveIsolatedExecutionModel,
+} from "../core/session-isolated-runtime.js";
+
+describe("session isolated runtime helpers", () => {
+  const availableModels = [
+    { id: "preferred", provider: "openai" },
+    { id: "fallback", provider: "openai" },
+  ];
+
+  it("uses an explicit model without consulting agent preferences", () => {
+    const explicitModel = { id: "explicit", provider: "test" };
+    expect(resolveIsolatedExecutionModel({
+      explicitModel,
+      targetAgent: { config: { models: { chat: "missing" } } },
+      availableModels,
+      defaultModel: { id: "default" },
+    })).toEqual({
+      model: explicitModel,
+      requestedModelId: null,
+      usedFallback: false,
+    });
+  });
+
+  it("falls back from a missing agent model to the global default then reports fallback", () => {
+    const resolved = resolveIsolatedExecutionModel({
+      targetAgent: {
+        yuan: "lynn",
+        config: { models: { chat: { id: "missing", provider: "openai" } } },
+      },
+      availableModels,
+      defaultModel: { id: "fallback", provider: "openai" },
+    });
+
+    expect(resolved.model.id).toBe("fallback");
+    expect(resolved.requestedModelId).toBe("missing");
+    expect(resolved.usedFallback).toBe(true);
+  });
+
+  it("filters isolated custom and builtin tools", () => {
+    const runtime = prepareIsolatedToolRuntime({
+      execCwd: "/tmp/work",
+      targetAgent: {
+        agentDir: "/tmp/agent",
+        tools: [{ name: "unused" }],
+        config: { desk: { patrol_tools: ["web_search"] } },
+      },
+      execModel: { id: "m", provider: "openai" },
+      buildTools: (_cwd, customTools, opts) => ({
+        tools: [{ name: "read" }, { name: "write" }],
+        customTools: [{ name: "web_search" }, { name: "todo" }],
+        customToolsArg: customTools,
+        opts,
+      }),
+      getSessionPath: () => "/tmp/session.jsonl",
+      builtinFilter: ["read"],
+    });
+
+    expect(runtime.suppressClientTools).toBe(false);
+    expect(runtime.tools).toEqual([{ name: "read" }]);
+    expect(runtime.customTools).toEqual([{ name: "web_search" }]);
+  });
+
+  it("exposes a stable default patrol tool allowlist", () => {
+    expect(PATROL_TOOLS_DEFAULT).toContain("web_search");
+    expect(PATROL_TOOLS_DEFAULT).toContain("message_agent");
+  });
+});


### PR DESCRIPTION
## Summary
- Extract isolated execution model selection and fallback bookkeeping into `core/session-isolated-runtime.ts`
- Extract isolated custom/builtin tool filtering behind `prepareIsolatedToolRuntime`
- Re-export `PATROL_TOOLS_DEFAULT` for compatibility and add focused unit coverage

## Validation
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npx vitest run tests/session-isolated-runtime.test.js tests/session-coordinator.test.js --reporter=dot`
- `npm run release:gate`

No local model assets were downloaded.