### PR TITLE
stability: centralize TTS UI preferences

### DIFF
--- a/desktop/src/react/__tests__/stores/voice-slice.test.ts
+++ b/desktop/src/react/__tests__/stores/voice-slice.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVoiceSlice, type VoiceSlice } from '../../stores/voice-slice';
+
+function installLocalStorageMock(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial));
+  const storage = {
+    getItem: vi.fn((key: string) => data.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => { data.set(key, value); }),
+    removeItem: vi.fn((key: string) => { data.delete(key); }),
+    clear: vi.fn(() => { data.clear(); }),
+  };
+  vi.stubGlobal('localStorage', storage);
+  return storage;
+}
+
+function makeSlice(): VoiceSlice {
+  let state: VoiceSlice;
+  const set = (partial: Partial<VoiceSlice>) => {
+    state = { ...state, ...partial };
+  };
+  state = createVoiceSlice(set);
+  return new Proxy({} as VoiceSlice, {
+    get: (_, key: string) => (state as unknown as Record<string, unknown>)[key],
+  });
+}
+
+describe('voice-slice', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses safe defaults when localStorage is empty', () => {
+    installLocalStorageMock();
+    const slice = makeSlice();
+    expect(slice.ttsAutoPrefetch).toBe(false);
+    expect(slice.ttsStreamingEnabled).toBe(true);
+    expect(slice.ttsBrowserFallbackEnabled).toBe(true);
+    expect(slice.ttsProviderPreference).toBe(null);
+  });
+
+  it('reads persisted preferences', () => {
+    installLocalStorageMock({
+      'lynn-tts-auto-prefetch': '1',
+      'lynn-tts-streaming-enabled': '0',
+      'lynn-tts-browser-fallback-enabled': '0',
+    });
+    const slice = makeSlice();
+    expect(slice.ttsAutoPrefetch).toBe(true);
+    expect(slice.ttsStreamingEnabled).toBe(false);
+    expect(slice.ttsBrowserFallbackEnabled).toBe(false);
+  });
+
+  it('persists toggles through setters', () => {
+    const storage = installLocalStorageMock();
+    const slice = makeSlice();
+    slice.setTtsAutoPrefetch(true);
+    slice.setTtsStreamingEnabled(false);
+    slice.setTtsBrowserFallbackEnabled(false);
+
+    expect(slice.ttsAutoPrefetch).toBe(true);
+    expect(slice.ttsStreamingEnabled).toBe(false);
+    expect(slice.ttsBrowserFallbackEnabled).toBe(false);
+    expect(storage.setItem).toHaveBeenCalledWith('lynn-tts-auto-prefetch', '1');
+    expect(storage.setItem).toHaveBeenCalledWith('lynn-tts-streaming-enabled', '0');
+    expect(storage.setItem).toHaveBeenCalledWith('lynn-tts-browser-fallback-enabled', '0');
+  });
+});

--- a/desktop/src/react/components/chat/AssistantMessage.tsx
+++ b/desktop/src/react/components/chat/AssistantMessage.tsx
@@ -277,6 +277,9 @@ export const AssistantMessage = memo(function AssistantMessage({ message, showAv
   const agentAvatarUrl = useStore(s => s.agentAvatarUrl);
   const sessionAgent = useStore(s => s.sessionAgent);
   const addToast = useStore(s => s.addToast);
+  const ttsAutoPrefetch = useStore(s => s.ttsAutoPrefetch);
+  const ttsStreamingEnabled = useStore(s => s.ttsStreamingEnabled);
+  const ttsBrowserFallbackEnabled = useStore(s => s.ttsBrowserFallbackEnabled);
   const [avatarFailed, setAvatarFailed] = useState(false);
 
   const displayName = sessionAgent?.name || agentName;
@@ -380,7 +383,7 @@ export const AssistantMessage = memo(function AssistantMessage({ message, showAv
   useEffect(() => () => stopTtsPlayback(), [stopTtsPlayback]);
 
   // ── P0 [2026-05-28]: TTS pre-synth on streaming end ──────────────
-  // streaming 结束时,如果用户开了 lynn-tts-auto-prefetch + 内容 > 50 字,后台
+  // streaming 结束时,如果用户开了自动预合成 + 内容 > 50 字,后台
   // fire-and-forget 调 tts_speak 把音频烤进 plugin cache。用户点喇叭时大概率
   // 直接缓存命中,即时播放(0 等待)。短内容(<50字)不触发避免烧 quota。
   const prefetchFiredRef = useRef(false);
@@ -388,9 +391,7 @@ export const AssistantMessage = memo(function AssistantMessage({ message, showAv
     if (isStreamMsg) return;                          // 还在 streaming,等
     if (prefetchFiredRef.current) return;             // 已 fire 过(防重)
     if (!plainText || plainText.length < 50) return;  // 太短,不值得 prefetch
-    let enabled = false;
-    try { enabled = localStorage.getItem('lynn-tts-auto-prefetch') === '1'; } catch { /* localStorage may be unavailable */ }
-    if (!enabled) return;
+    if (!ttsAutoPrefetch) return;
     prefetchFiredRef.current = true;
     // Fire-and-forget,失败也不影响用户体验
     hanaFetch('/api/tools/tts-bridge.tts_speak', {
@@ -408,7 +409,7 @@ export const AssistantMessage = memo(function AssistantMessage({ message, showAv
         if (audioPath) setTtsAudioPath(audioPath);  // 预设 path 让用户点喇叭直接走 startPlayback 分支
       })
       .catch(() => { /* silent */ });
-  }, [isStreamMsg, plainText, message.id]);
+  }, [isStreamMsg, plainText, message.id, ttsAutoPrefetch]);
 
   // ── P2 [2026-05-28]: Browser SpeechSynthesis instant fallback ──
   // Shift+click 喇叭 → 浏览器原生 TTS,TTFB <50ms,完全本地。音色弱但 draft 朗读 OK
@@ -800,7 +801,7 @@ export const AssistantMessage = memo(function AssistantMessage({ message, showAv
                 className={styles.msgCopyBtn}
                 onClick={async (e) => {
                   // P2 [2026-05-28]: Shift+click → 浏览器原生 SpeechSynthesis(TTFB <50ms,本地)
-                  if (e.shiftKey) {
+                  if (e.shiftKey && ttsBrowserFallbackEnabled) {
                     if (window.speechSynthesis.speaking) {
                       window.speechSynthesis.cancel();
                       addToast('已停止浏览器朗读', 'info');
@@ -854,11 +855,13 @@ export const AssistantMessage = memo(function AssistantMessage({ message, showAv
                         setTtsAudioPath(null);
                       }
                     }
-                    try {
-                      await startStreamPlayback();
-                      return;
-                    } catch (streamErr) {
-                      console.warn('[tts] stream playback unavailable, falling back to file TTS:', streamErr);
+                    if (ttsStreamingEnabled) {
+                      try {
+                        await startStreamPlayback();
+                        return;
+                      } catch (streamErr) {
+                        console.warn('[tts] stream playback unavailable, falling back to file TTS:', streamErr);
+                      }
                     }
                     addToast('准备朗读…', 'info');
                     const res = await hanaFetch('/api/tools/tts-bridge.tts_speak', {

--- a/desktop/src/react/settings/tabs/VoiceTab.tsx
+++ b/desktop/src/react/settings/tabs/VoiceTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useSettingsStore } from '../store';
+import { useStore } from '../../stores';
 import { autoSaveConfig } from '../helpers';
 import { SelectWidget } from '../widgets/SelectWidget';
 import { KeyInput } from '../widgets/KeyInput';
@@ -94,10 +95,13 @@ export function VoiceTab() {
   const [ttsKey, setTtsKey] = useState(voice.tts?.api_key || '');
   const [ttsBaseUrl, setTtsBaseUrl] = useState(voice.tts?.base_url || '');
   const [ttsVoice, setTtsVoice] = useState(voice.tts?.default_voice || defaultTtsVoice(voice.tts?.provider || 'cosyvoice'));
-  // P0 [2026-05-28]: 流结束自动预合成,用户点喇叭即时播放(缓存命中)
-  const [ttsAutoPrefetch, setTtsAutoPrefetch] = useState(() => {
-    try { return localStorage.getItem('lynn-tts-auto-prefetch') === '1'; } catch { return false; }
-  });
+  const ttsAutoPrefetch = useStore((s) => s.ttsAutoPrefetch);
+  const ttsStreamingEnabled = useStore((s) => s.ttsStreamingEnabled);
+  const ttsBrowserFallbackEnabled = useStore((s) => s.ttsBrowserFallbackEnabled);
+  const setTtsAutoPrefetch = useStore((s) => s.setTtsAutoPrefetch);
+  const setTtsStreamingEnabled = useStore((s) => s.setTtsStreamingEnabled);
+  const setTtsBrowserFallbackEnabled = useStore((s) => s.setTtsBrowserFallbackEnabled);
+  const setTtsProviderPreference = useStore((s) => s.setTtsProviderPreference);
   // MiMo voice clone / design
   const [mimoVoiceClonePath, setMimoVoiceClonePath] = useState<string>(String(voice.tts?.voice_clone_audio_path || ''));
   const [mimoVoiceDescription, setMimoVoiceDescription] = useState<string>(String(voice.tts?.voice_description || ''));
@@ -115,13 +119,14 @@ export function VoiceTab() {
     setAsrBaseUrl(v.asr?.base_url || '');
     const nextTtsProvider = v.tts?.provider || 'cosyvoice';
     setTtsProvider(nextTtsProvider);
+    setTtsProviderPreference(nextTtsProvider);
     setTtsKey(v.tts?.api_key || '');
     setTtsBaseUrl(v.tts?.base_url || '');
     setTtsVoice(v.tts?.default_voice || defaultTtsVoice(nextTtsProvider));
     setMimoVoiceClonePath(String(v.tts?.voice_clone_audio_path || ''));
     setMimoVoiceDescription(String(v.tts?.voice_description || ''));
     setLanguage(v.language || 'auto');
-  }, [settingsConfig?.voice]);
+  }, [settingsConfig?.voice, setTtsProviderPreference]);
 
   useEffect(() => {
     let cancelled = false;
@@ -276,6 +281,7 @@ export function VoiceTab() {
             value={ttsProvider}
             onChange={(v) => {
               setTtsProvider(v);
+              setTtsProviderPreference(v);
               setTtsVoice(defaultTtsVoice(v));
             }}
           />
@@ -355,11 +361,7 @@ export function VoiceTab() {
             <input
               type="checkbox"
               checked={ttsAutoPrefetch}
-              onChange={(e) => {
-                const v = e.target.checked;
-                setTtsAutoPrefetch(v);
-                try { localStorage.setItem('lynn-tts-auto-prefetch', v ? '1' : '0'); } catch { /* localStorage may be unavailable */ }
-              }}
+              onChange={(e) => setTtsAutoPrefetch(e.target.checked)}
             />
             <span>消息流结束后自动预合成语音(点喇叭即时播放)</span>
           </label>
@@ -367,6 +369,34 @@ export function VoiceTab() {
             开启后:每条 ≥50 字回复在 streaming 结束时后台 TTS 一次,缓存到磁盘。点喇叭命中缓存 0 等待。
             注意:每条都烧 TTS quota,MiMo/OpenAI 收费 provider 慎开。CosyVoice/Edge 免费可开。
             ⚡ Shift+点击 喇叭 = 浏览器原生即时朗读(本地,&lt;50ms,无 quota)。
+          </span>
+        </div>
+
+        <div className={styles['settings-field']}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={ttsStreamingEnabled}
+              onChange={(e) => setTtsStreamingEnabled(e.target.checked)}
+            />
+            <span>优先使用流式播放(可用时更快开声)</span>
+          </label>
+          <span className={styles['settings-field-hint']}>
+            CosyVoice 支持真流式时会优先边合成边播放;失败会自动回退到普通文件合成。
+          </span>
+        </div>
+
+        <div className={styles['settings-field']}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={ttsBrowserFallbackEnabled}
+              onChange={(e) => setTtsBrowserFallbackEnabled(e.target.checked)}
+            />
+            <span>允许 Shift+点击使用浏览器即时朗读</span>
+          </label>
+          <span className={styles['settings-field-hint']}>
+            完全本地、无 quota,适合快速听草稿;关闭后 Shift+点击会按普通朗读处理。
           </span>
         </div>
 

--- a/desktop/src/react/stores/index.ts
+++ b/desktop/src/react/stores/index.ts
@@ -20,6 +20,7 @@ import { createBridgeSlice, type BridgeSlice } from './bridge-slice';
 import { createSecuritySlice, type SecuritySlice } from './security-slice';
 import { createStartupSlice, type StartupSlice } from './startup-slice';
 import { createTaskModeSlice, type TaskModeSlice } from './task-mode-slice';
+import { createVoiceSlice, type VoiceSlice } from './voice-slice';
 
 export type StoreState = ConnectionSlice &
   SessionSlice &
@@ -40,7 +41,8 @@ export type StoreState = ConnectionSlice &
   BridgeSlice &
   SecuritySlice &
   StartupSlice &
-  TaskModeSlice;
+  TaskModeSlice &
+  VoiceSlice;
 
 export const useStore = create<StoreState>()((set, _get, _api) => ({
   ...createConnectionSlice(set),
@@ -63,6 +65,7 @@ export const useStore = create<StoreState>()((set, _get, _api) => ({
   ...createSecuritySlice(set),
   ...createStartupSlice(set),
   ...createTaskModeSlice(set),
+  ...createVoiceSlice(set),
 }));
 
 export { useShallow };
@@ -89,4 +92,5 @@ export type {
   SecuritySlice,
   StartupSlice,
   TaskModeSlice,
+  VoiceSlice,
 };

--- a/desktop/src/react/stores/voice-slice.ts
+++ b/desktop/src/react/stores/voice-slice.ts
@@ -1,0 +1,56 @@
+export type TtsProviderPreference = 'cosyvoice' | 'edge' | 'mimo' | 'openai' | 'say' | string;
+
+const TTS_AUTO_PREFETCH_KEY = 'lynn-tts-auto-prefetch';
+const TTS_STREAMING_KEY = 'lynn-tts-streaming-enabled';
+const TTS_BROWSER_FALLBACK_KEY = 'lynn-tts-browser-fallback-enabled';
+
+function readBoolPreference(key: string, fallback: boolean): boolean {
+  try {
+    const stored = localStorage.getItem(key);
+    if (stored === null) return fallback;
+    return stored === '1';
+  } catch {
+    return fallback;
+  }
+}
+
+function writeBoolPreference(key: string, value: boolean): void {
+  try {
+    localStorage.setItem(key, value ? '1' : '0');
+  } catch {
+    // localStorage may be unavailable in tests / hardened browser contexts.
+  }
+}
+
+export interface VoiceSlice {
+  ttsAutoPrefetch: boolean;
+  ttsStreamingEnabled: boolean;
+  ttsBrowserFallbackEnabled: boolean;
+  ttsProviderPreference: TtsProviderPreference | null;
+  setTtsAutoPrefetch: (enabled: boolean) => void;
+  setTtsStreamingEnabled: (enabled: boolean) => void;
+  setTtsBrowserFallbackEnabled: (enabled: boolean) => void;
+  setTtsProviderPreference: (provider: TtsProviderPreference | null) => void;
+}
+
+export const createVoiceSlice = (
+  set: (partial: Partial<VoiceSlice>) => void,
+): VoiceSlice => ({
+  ttsAutoPrefetch: readBoolPreference(TTS_AUTO_PREFETCH_KEY, false),
+  ttsStreamingEnabled: readBoolPreference(TTS_STREAMING_KEY, true),
+  ttsBrowserFallbackEnabled: readBoolPreference(TTS_BROWSER_FALLBACK_KEY, true),
+  ttsProviderPreference: null,
+  setTtsAutoPrefetch: (enabled) => {
+    writeBoolPreference(TTS_AUTO_PREFETCH_KEY, enabled);
+    set({ ttsAutoPrefetch: enabled });
+  },
+  setTtsStreamingEnabled: (enabled) => {
+    writeBoolPreference(TTS_STREAMING_KEY, enabled);
+    set({ ttsStreamingEnabled: enabled });
+  },
+  setTtsBrowserFallbackEnabled: (enabled) => {
+    writeBoolPreference(TTS_BROWSER_FALLBACK_KEY, enabled);
+    set({ ttsBrowserFallbackEnabled: enabled });
+  },
+  setTtsProviderPreference: (provider) => set({ ttsProviderPreference: provider }),
+});


### PR DESCRIPTION
## Summary
- Add a `voice-slice` for TTS UI preferences with localStorage-backed defaults
- Move auto-prefetch, streaming playback, and browser fallback toggles out of ad hoc component state
- Wire AssistantMessage to the shared preferences and add store unit coverage

## Validation
- `npm run typecheck`
- `npx vitest run desktop/src/react/__tests__/stores/voice-slice.test.ts --reporter=dot`
- `npx vitest run desktop/src/react/__tests__/stores --reporter=dot`
- `npm run build:renderer`
- `npm run release:gate`

No local model assets were downloaded.