### PR TITLE
docs(plugins): add SDK types

### DIFF
--- a/plugins/_types/README.md
+++ b/plugins/_types/README.md
@@ -1,0 +1,20 @@
+# Lynn Plugin Types
+
+Plugin implementations stay in JavaScript so plugin authors can work without a build step. These `.d.ts` files provide editor hints and shared contracts for tools, routes, manifests, and plugin context objects.
+
+Example:
+
+```js
+/** @typedef {import("../_types").PluginToolContext} PluginToolContext */
+
+/**
+ * @param {{ text: string }} params
+ * @param {PluginToolContext} ctx
+ */
+export async function execute(params, ctx) {
+  ctx.log.info?.("speak", params.text);
+}
+```
+
+Use these types for new first-party plugins and for documentation examples. Do not convert third-party or user-authored plugins to TypeScript just for coverage.
+

--- a/plugins/_types/index.d.ts
+++ b/plugins/_types/index.d.ts
@@ -1,0 +1,96 @@
+import type { TSchema } from '@sinclair/typebox';
+import type { Hono } from 'hono';
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+export type JsonRecord = Record<string, JsonValue>;
+
+export interface PluginLogger {
+  debug?: (...args: unknown[]) => void;
+  info?: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+  error?: (...args: unknown[]) => void;
+  log?: (...args: unknown[]) => void;
+}
+
+export interface PluginConfigAccessor {
+  get(): JsonRecord;
+  get<T = unknown>(key: string): T | undefined;
+  set?<T = unknown>(key: string, value: T): void | Promise<void>;
+}
+
+export interface PluginBus {
+  emit?(event: string, payload?: unknown): void | Promise<void>;
+  on?(event: string, handler: (...args: unknown[]) => void | Promise<void>): unknown;
+}
+
+export interface PluginToolContext {
+  pluginId?: string;
+  pluginDir: string;
+  dataDir: string;
+  bus?: PluginBus | null;
+  engine?: unknown;
+  config?: PluginConfigAccessor;
+  log: PluginLogger;
+}
+
+export interface PluginToolResult {
+  content?: Array<{
+    type: 'text' | 'image' | 'audio' | 'file' | string;
+    text?: string;
+    path?: string;
+    mimeType?: string;
+    [key: string]: unknown;
+  }>;
+  details?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface PluginToolModule<Params = Record<string, unknown>, Result = PluginToolResult> {
+  name: string;
+  description: string;
+  parameters: TSchema;
+  execute(params: Params, ctx: PluginToolContext): Result | Promise<Result>;
+}
+
+export interface PluginCommandModule<Params = unknown, Result = unknown> {
+  name: string;
+  description?: string;
+  execute(params: Params, ctx: PluginToolContext): Result | Promise<Result>;
+}
+
+export interface PluginRouteModule {
+  register(app: Hono, ctx: PluginToolContext): void | Promise<void>;
+}
+
+export interface PluginLifecycleModule {
+  onload?(ctx: PluginToolContext): void | Promise<void>;
+  onunload?(ctx: PluginToolContext): void | Promise<void>;
+}
+
+export interface PluginConfigurationProperty {
+  type: 'string' | 'number' | 'boolean' | 'integer' | 'array' | 'object';
+  title?: string;
+  default?: JsonValue;
+  enum?: JsonValue[];
+  minimum?: number;
+  maximum?: number;
+  description?: string;
+  [key: string]: JsonValue | undefined;
+}
+
+export interface PluginConfigurationContribution {
+  properties?: Record<string, PluginConfigurationProperty>;
+}
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  contributes?: {
+    configuration?: PluginConfigurationContribution;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}

--- a/plugins/tts-bridge/manifest.json
+++ b/plugins/tts-bridge/manifest.json
@@ -44,12 +44,6 @@
           "title": "MiMo API Key (仅 mimo provider 需要)",
           "default": "",
           "description": "MiMo Token Plan API key（tp-* 前缀）。也可通过环境变量 MIMO_TTS_KEY / MIMO_SEARCH_KEY 配置。"
-        },
-        "auto_tts_for_long_text": {
-          "type": "boolean",
-          "title": "Auto TTS for Long Text",
-          "default": false,
-          "description": "当 Agent 输出超过 500 字时，自动询问是否生成语音摘要。（v0.77 计划中，当前不生效）"
         }
       }
     }

--- a/plugins/tts-bridge/tools/tts-speak.js
+++ b/plugins/tts-bridge/tools/tts-speak.js
@@ -1,5 +1,6 @@
 /**
  * tts-speak.js — 文本转语音工具（v0.77 真实实现）
+ * @typedef {import("../../_types").PluginToolContext} PluginToolContext
  */
 import fs from "fs";
 import path from "path";
@@ -67,6 +68,10 @@ export async function normalizeSpeechText(value) {
   return normalizeChineseTtsTextImpl(value);
 }
 
+/**
+ * @param {{ text: string; voice?: string; speed?: number; filename?: string }} params
+ * @param {Partial<PluginToolContext>} ctx
+ */
 export async function execute(params, ctx = {}) {
   const { text, voice, speed, filename } = params;
   const { log = console, config } = ctx;


### PR DESCRIPTION
## Summary
- add `plugins/_types` declarations for plugin tools, routes, manifests, context, and logger shapes
- document the JS + `.d.ts` plugin authoring pattern
- annotate `tts-bridge` speak tool params/context with JSDoc
- remove inactive `auto_tts_for_long_text` manifest config now superseded by UI voice preferences

## Validation
- `npm run typecheck`
- `node -e "JSON.parse(require('fs').readFileSync('plugins/tts-bridge/manifest.json','utf8'))"`
- `npm test -- --reporter=dot tests/plugin-manager.test.js`

No local model/model-data assets were downloaded.