### PR TITLE
refactor(session): extract cache and relay orchestration

### DIFF
--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -65,15 +65,14 @@ import {
 } from "./session-tool-runtime.js";
 import {
   MAX_CACHED_SESSIONS,
-  buildCurrentSessionListEntry,
-  collectAgentSessionEntries,
   evictSessionCacheEntries,
+  listCoordinatorSessions,
   refreshMissingSessionIndexes,
-  sortSessionEntriesByModified,
 } from "./session-list-cache.js";
 import {
   formatRelaySummaryContext,
   resolveSessionRelayConfig,
+  runSessionRelay,
 } from "./session-relay.js";
 import { promoteActivitySessionFile } from "./session-activity.js";
 import {
@@ -1195,26 +1194,19 @@ export class SessionCoordinator {
   }
 
   async listSessions() {
-    const allSessions = await collectAgentSessionEntries({
+    return listCoordinatorSessions({
       agentsDir: this._d.agentsDir,
       agents: this._d.listAgents(),
+      currentPath: this.currentSessionPath,
+      sessionStarted: this._sessionStarted,
+      currentSession: this._session,
+      currentEntry: this.currentSessionPath ? this._sessions.get(this.currentSessionPath) : null,
+      activeAgentId: this._d.getActiveAgentId(),
+      activeAgent: this._d.getAgent(),
       onIndexRefreshError: (agent, err) => {
         log.warn(`session index refresh failed · agent=${agent.id} · ${errMessage(err)}`);
       },
     });
-    const currentPath = this.currentSessionPath;
-    const currentEntry = buildCurrentSessionListEntry({
-      currentPath,
-      sessionStarted: this._sessionStarted,
-      allSessions,
-      currentSession: this._session,
-      currentEntry: currentPath ? this._sessions.get(currentPath) : null,
-      activeAgentId: this._d.getActiveAgentId(),
-      activeAgent: this._d.getAgent(),
-    });
-    if (currentEntry) allSessions.unshift(currentEntry);
-
-    return sortSessionEntriesByModified(allSessions);
   }
 
   async _refreshSessionIndexesInBackground() {
@@ -1495,64 +1487,43 @@ export class SessionCoordinator {
   }
 
   async _relaySession(sessionPath: string, compactionCount: number) {
-    const entry = this._sessions.get(sessionPath);
-    if (!entry || entry.relayInProgress) return false;
-
-    const relayCfg = this._resolveSessionRelayConfig();
-    if (!relayCfg.enabled || sessionPath !== this.currentSessionPath) return false;
-
     const prevPendingPlanMode = this._pendingPlanMode;
     const prevPendingSecurityMode = this._pendingSecurityMode;
-    entry.relayInProgress = true;
-    try {
-      const summary = await this._d.summarizeSessionRelay?.(sessionPath, {
-        maxTokens: relayCfg.summaryMaxTokens,
-      });
-      if (!summary) return false;
-
-      const models = this._d.getModels();
-      const model = entry.modelId
-        ? findModel(models.availableModels, entry.modelId, entry.modelProvider || undefined)
-        : (this._session?.model || models.currentModel);
-      const cwd = entry.session?.sessionManager?.getCwd?.() || this._d.getHomeCwd() || process.cwd();
-
-      this._pendingPlanMode = !!entry.planMode;
-      this._pendingSecurityMode = entry.securityMode || DEFAULT_SECURITY_MODE;
-
-      const nextSession = await this.createSession(null, cwd, entry.memoryEnabled !== false, model);
-      const newSessionPath = nextSession?.sessionManager?.getSessionFile?.() || this.currentSessionPath;
-      const newEntry = newSessionPath ? this._sessions.get(newSessionPath) : null;
-      if (!newEntry || !newSessionPath) return false;
-
-      newEntry._relaySummaryContext = this._formatRelaySummaryContext(summary);
-      newEntry.compactionCount = 0;
-      newEntry.securityMode = entry.securityMode || DEFAULT_SECURITY_MODE;
-      newEntry.planMode = !!entry.planMode;
-      newEntry.memoryEnabled = entry.memoryEnabled !== false;
-      this._applySessionToolRuntime(newSessionPath, newEntry.securityMode);
-
-      this._d.emitEvent({
-        type: "session_relay",
-        oldSessionPath: sessionPath,
-        newSessionPath,
-        summary,
-        summaryTokens: summary.length,
-        compactionCount,
-        reason: "auto_compaction_limit",
-      }, newSessionPath);
-      return true;
-    } catch (err) {
-      log.warn(`session relay failed: ${errMessage(err)}`);
-      return false;
-    } finally {
-      this._pendingPlanMode = prevPendingPlanMode;
-      this._pendingSecurityMode = prevPendingSecurityMode;
-      const current = this._sessions.get(sessionPath);
-      if (current) {
-        current.relayInProgress = false;
-        current.compactionCount = 0;
-      }
-    }
+    return runSessionRelay({
+      sessionPath,
+      compactionCount,
+      sessions: this._sessions,
+      currentSessionPath: this.currentSessionPath,
+      getCurrentSessionPath: () => this.currentSessionPath,
+      relayConfig: this._resolveSessionRelayConfig(),
+      defaultSecurityMode: DEFAULT_SECURITY_MODE,
+      summarize: async (path, options) => (
+        this._d.summarizeSessionRelay
+          ? await this._d.summarizeSessionRelay(path, options)
+          : null
+      ),
+      resolveModel: (entry) => {
+        const models = this._d.getModels();
+        return entry.modelId
+          ? findModel(models.availableModels, entry.modelId, entry.modelProvider || undefined)
+          : (this._session?.model || models.currentModel);
+      },
+      resolveCwd: (entry) => entry.session?.sessionManager?.getCwd?.() || this._d.getHomeCwd() || process.cwd(),
+      createSession: async ({ entry, cwd, memoryEnabled, model }) => {
+        this._pendingPlanMode = !!entry.planMode;
+        this._pendingSecurityMode = entry.securityMode || DEFAULT_SECURITY_MODE;
+        try {
+          return await this.createSession(null, cwd, memoryEnabled, model as ModelLike);
+        } finally {
+          this._pendingPlanMode = prevPendingPlanMode;
+          this._pendingSecurityMode = prevPendingSecurityMode;
+        }
+      },
+      formatSummaryContext: (summary) => this._formatRelaySummaryContext(summary),
+      applySessionToolRuntime: (path, mode) => this._applySessionToolRuntime(path, mode),
+      emitEvent: (event, path) => this._d.emitEvent(event, path),
+      onError: (err) => log.warn(`session relay failed: ${errMessage(err)}`),
+    });
   }
 
   async _prepareDryRunWorkspace(sourceDir: string) {

--- a/core/session-list-cache.ts
+++ b/core/session-list-cache.ts
@@ -153,6 +153,35 @@ export function sortSessionEntriesByModified(sessions: AnyRecord[]) {
   return sessions;
 }
 
+export async function listCoordinatorSessions(opts: {
+  agentsDir: string;
+  agents: AgentLike[];
+  currentPath?: string | null;
+  sessionStarted: boolean;
+  currentSession?: SessionLike | null;
+  currentEntry?: SessionEntryLike | null;
+  activeAgentId: string;
+  activeAgent: AgentLike;
+  onIndexRefreshError?: (agent: AgentLike, err: unknown) => void;
+}) {
+  const allSessions = await collectAgentSessionEntries({
+    agentsDir: opts.agentsDir,
+    agents: opts.agents,
+    onIndexRefreshError: opts.onIndexRefreshError,
+  });
+  const currentEntry = buildCurrentSessionListEntry({
+    currentPath: opts.currentPath,
+    sessionStarted: opts.sessionStarted,
+    allSessions,
+    currentSession: opts.currentSession,
+    currentEntry: opts.currentEntry,
+    activeAgentId: opts.activeAgentId,
+    activeAgent: opts.activeAgent,
+  });
+  if (currentEntry) allSessions.unshift(currentEntry);
+  return sortSessionEntriesByModified(allSessions);
+}
+
 export function evictSessionCacheEntries(opts: {
   sessions: Map<string, SessionEntryLike>;
   currentKey: string;

--- a/core/session-relay.ts
+++ b/core/session-relay.ts
@@ -2,6 +2,14 @@ import { getLocale } from "../server/i18n.js";
 import { resolveModelContextWindow } from "./compaction-settings.js";
 
 type AnyRecord = Record<string, any>;
+type SessionRelayEntry = AnyRecord & {
+  session?: AnyRecord;
+  memoryEnabled?: boolean;
+  planMode?: boolean;
+  securityMode?: string;
+  relayInProgress?: boolean;
+  compactionCount?: number;
+};
 
 const SESSION_RELAY_SUMMARY_MAX_CHARS = 4000;
 
@@ -33,4 +41,78 @@ export function formatRelaySummaryContext(summaryText: string, locale = getLocal
   return isZh
     ? `【上一个会话的自动接力摘要】\n以下是上一段长会话在压缩多次后的交接摘要。请把它当作继续工作的背景，不要逐字复述给用户，除非用户明确询问：\n${summary}`
     : `[Automatic Session Relay Summary]\nThe following is a handoff summary from the previous long-running session after repeated compactions. Use it as continuation context and do not quote it back unless the user asks for it:\n${summary}`;
+}
+
+export async function runSessionRelay(opts: {
+  sessionPath: string;
+  compactionCount: number;
+  sessions: Map<string, SessionRelayEntry>;
+  currentSessionPath?: string | null;
+  getCurrentSessionPath: () => string | null | undefined;
+  relayConfig: ReturnType<typeof resolveSessionRelayConfig>;
+  defaultSecurityMode: string;
+  summarize: (sessionPath: string, options: { maxTokens: number }) => Promise<string | null | undefined>;
+  resolveModel: (entry: SessionRelayEntry) => unknown;
+  resolveCwd: (entry: SessionRelayEntry) => string;
+  createSession: (options: {
+    entry: SessionRelayEntry;
+    cwd: string;
+    memoryEnabled: boolean;
+    model: unknown;
+  }) => Promise<AnyRecord | null | undefined>;
+  formatSummaryContext: (summaryText: string) => string;
+  applySessionToolRuntime: (sessionPath: string, modeOverride?: string | null) => void;
+  emitEvent: (event: AnyRecord, sessionPath: string) => void;
+  onError?: (err: unknown) => void;
+}) {
+  const entry = opts.sessions.get(opts.sessionPath);
+  if (!entry || entry.relayInProgress) return false;
+  if (!opts.relayConfig.enabled || opts.sessionPath !== opts.currentSessionPath) return false;
+
+  entry.relayInProgress = true;
+  try {
+    const summary = await opts.summarize(opts.sessionPath, {
+      maxTokens: opts.relayConfig.summaryMaxTokens,
+    });
+    if (!summary) return false;
+
+    const model = opts.resolveModel(entry);
+    const cwd = opts.resolveCwd(entry);
+    const nextSession = await opts.createSession({
+      entry,
+      cwd,
+      memoryEnabled: entry.memoryEnabled !== false,
+      model,
+    });
+    const newSessionPath = nextSession?.sessionManager?.getSessionFile?.() || opts.getCurrentSessionPath();
+    const newEntry = newSessionPath ? opts.sessions.get(newSessionPath) : null;
+    if (!newEntry || !newSessionPath) return false;
+
+    newEntry._relaySummaryContext = opts.formatSummaryContext(summary);
+    newEntry.compactionCount = 0;
+    newEntry.securityMode = entry.securityMode || opts.defaultSecurityMode;
+    newEntry.planMode = !!entry.planMode;
+    newEntry.memoryEnabled = entry.memoryEnabled !== false;
+    opts.applySessionToolRuntime(newSessionPath, newEntry.securityMode);
+
+    opts.emitEvent({
+      type: "session_relay",
+      oldSessionPath: opts.sessionPath,
+      newSessionPath,
+      summary,
+      summaryTokens: summary.length,
+      compactionCount: opts.compactionCount,
+      reason: "auto_compaction_limit",
+    }, newSessionPath);
+    return true;
+  } catch (err) {
+    opts.onError?.(err);
+    return false;
+  } finally {
+    const current = opts.sessions.get(opts.sessionPath);
+    if (current) {
+      current.relayInProgress = false;
+      current.compactionCount = 0;
+    }
+  }
 }

--- a/tests/session-list-cache.test.js
+++ b/tests/session-list-cache.test.js
@@ -4,6 +4,7 @@ import path from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   evictSessionCacheEntries,
+  listCoordinatorSessions,
   listSessionFileSkeletons,
 } from "../core/session-list-cache.js";
 
@@ -70,5 +71,33 @@ describe("session list/cache helpers", () => {
     expect(sessions.has("current")).toBe(true);
     expect(unsubOld).toHaveBeenCalledTimes(1);
     expect(notifySessionEnd).toHaveBeenCalledWith({ id: "a1" }, "old", "cache eviction");
+  });
+
+  it("lists coordinator sessions with an in-flight current session", async () => {
+    const root = tempDir();
+    const sessionDir = path.join(root, "agent-a", "sessions");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const oldPath = path.join(sessionDir, "old.jsonl");
+    fs.writeFileSync(oldPath, "{}\n");
+
+    const currentPath = path.join(sessionDir, "current.jsonl");
+    const sessions = await listCoordinatorSessions({
+      agentsDir: root,
+      agents: [{ id: "agent-a", name: "Agent A" }],
+      currentPath,
+      sessionStarted: true,
+      currentSession: { sessionManager: { getCwd: () => "/tmp/workspace" } },
+      currentEntry: { modelId: "model-a", modelProvider: "provider-a" },
+      activeAgentId: "agent-a",
+      activeAgent: { id: "agent-a", agentName: "Agent A" },
+    });
+
+    expect(sessions[0]).toMatchObject({
+      path: currentPath,
+      cwd: "/tmp/workspace",
+      modelId: "model-a",
+      modelProvider: "provider-a",
+    });
+    expect(sessions.some((session) => session.path === oldPath)).toBe(true);
   });
 });

--- a/tests/session-relay.test.js
+++ b/tests/session-relay.test.js
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   formatRelaySummaryContext,
   resolveSessionRelayConfig,
+  runSessionRelay,
 } from "../core/session-relay.js";
 
 describe("session relay helpers", () => {
@@ -31,5 +32,59 @@ describe("session relay helpers", () => {
     const en = formatRelaySummaryContext("x".repeat(4100), "en-US");
     expect(en).toContain("Automatic Session Relay Summary");
     expect(en.length).toBeLessThan(4300);
+  });
+
+  it("creates a relay session and resets relay state", async () => {
+    const sessions = new Map([
+      ["old.jsonl", {
+        session: { sessionManager: { getCwd: () => "/tmp/workspace" } },
+        memoryEnabled: true,
+        planMode: true,
+        securityMode: "safe",
+        relayInProgress: false,
+        compactionCount: 3,
+      }],
+    ]);
+    const emitEvent = vi.fn();
+    const applySessionToolRuntime = vi.fn();
+
+    const ok = await runSessionRelay({
+      sessionPath: "old.jsonl",
+      compactionCount: 3,
+      sessions,
+      currentSessionPath: "old.jsonl",
+      getCurrentSessionPath: () => "new.jsonl",
+      relayConfig: { enabled: true, compactionThreshold: 3, summaryMaxTokens: 800 },
+      defaultSecurityMode: "execute",
+      summarize: vi.fn(async () => "keep going"),
+      resolveModel: vi.fn(() => ({ id: "m" })),
+      resolveCwd: (entry) => entry.session.sessionManager.getCwd(),
+      createSession: vi.fn(async () => {
+        sessions.set("new.jsonl", {});
+        return { sessionManager: { getSessionFile: () => "new.jsonl" } };
+      }),
+      formatSummaryContext: (summary) => `ctx:${summary}`,
+      applySessionToolRuntime,
+      emitEvent,
+    });
+
+    expect(ok).toBe(true);
+    expect(sessions.get("new.jsonl")).toMatchObject({
+      _relaySummaryContext: "ctx:keep going",
+      compactionCount: 0,
+      securityMode: "safe",
+      planMode: true,
+      memoryEnabled: true,
+    });
+    expect(sessions.get("old.jsonl")).toMatchObject({
+      relayInProgress: false,
+      compactionCount: 0,
+    });
+    expect(applySessionToolRuntime).toHaveBeenCalledWith("new.jsonl", "safe");
+    expect(emitEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: "session_relay",
+      oldSessionPath: "old.jsonl",
+      newSessionPath: "new.jsonl",
+    }), "new.jsonl");
   });
 });


### PR DESCRIPTION
## Summary
- move coordinator session-list orchestration into `listCoordinatorSessions()`
- move auto-relay execution into `runSessionRelay()` so the coordinator only wires dependencies
- add focused helper tests for current-session list insertion and relay state reset/event emission

## Validation
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npm test -- --reporter=dot tests/session-list-cache.test.js tests/session-relay.test.js tests/session-coordinator.test.js`
- `npm run release:gate`

No local model/model-data assets were downloaded.