### PR TITLE
refactor(chat): extract assistant message cards

### DIFF
--- a/desktop/src/react/components/chat/AssistantMessage.tsx
+++ b/desktop/src/react/components/chat/AssistantMessage.tsx
@@ -4,19 +4,17 @@
 
 import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { MarkdownContent } from './MarkdownContent';
-import { ImageBlock } from './ImageBlock';
 import { MoodBlock } from './MoodBlock';
 import { ThinkingBlock } from './ThinkingBlock';
 import { ExecutionTraceBlock } from './ExecutionTraceBlock';
 import { SettingsConfirmCard } from './SettingsConfirmCard';
 import { AuthorizationCard } from './AuthorizationCard';
 import { TtsControlButton } from './TtsControlButton';
+import { ArtifactCard, BrowserScreenshot, CronConfirmCard, FileOutputCard, SkillCard } from './MessageCards';
 import type { ChatMessage, ContentBlock } from '../../stores/chat-types';
 import { useStore } from '../../stores';
 import { hanaFetch } from '../../hooks/use-hana-fetch';
 import { useI18n } from '../../hooks/use-i18n';
-import { openFilePreview, openSkillPreview } from '../../utils/file-preview';
-import { openPreview } from '../../stores/artifact-actions';
 import { isBundledLynnAvatarSrc, yuanFallbackAvatar } from '../../utils/agent-helpers';
 import { buildRetryDraftFromMessage } from '../../utils/composer-state';
 import { formatCompactModelLabel } from '../../utils/brain-models';
@@ -188,6 +186,13 @@ function shouldShowFollowUpAction(reviewBlock: Extract<ContentBlock, { type: 're
   if (!reviewBlock || reviewBlock.status !== 'done') return false;
   if (!reviewBlock.followUpPrompt) return false;
   return reviewBlock.workflowGate === 'follow_up' || reviewBlock.workflowGate === 'hold';
+}
+
+function fallbackI18n(value: string | null | undefined, fallback: string): string {
+  if (!value) return fallback;
+  const trimmed = String(value).trim();
+  if (/^[a-z0-9_]+(?:\.[a-z0-9_]+)+$/i.test(trimmed)) return fallback;
+  return trimmed;
 }
 
 export const AssistantMessage = memo(function AssistantMessage({ message, showAvatar, isLastAssistant }: Props) {
@@ -805,287 +810,3 @@ const ContentBlockView = memo(function ContentBlockView({ block, agentName, agen
       return null;
   }
 });
-
-const EXT_LABELS: Record<string, string> = {
-  pdf: 'PDF', doc: 'Word', docx: 'Word', xls: 'Excel', xlsx: 'Excel',
-  ppt: 'Presentation', pptx: 'Presentation', md: 'Markdown', txt: 'Text',
-  html: 'HTML', htm: 'HTML', css: 'Stylesheet', json: 'JSON', yaml: 'YAML', yml: 'YAML',
-};
-
-function extLabel(ext: string): string {
-  return EXT_LABELS[ext.toLowerCase()] || ext.toUpperCase();
-}
-
-function fallbackI18n(value: string | null | undefined, fallback: string): string {
-  if (!value) return fallback;
-  const trimmed = String(value).trim();
-  if (/^[a-z0-9_]+(?:\.[a-z0-9_]+)+$/i.test(trimmed)) return fallback;
-  return trimmed;
-}
-
-function FileOutputCard({
-  filePath,
-  label,
-  ext,
-  openLabel,
-}: {
-  filePath: string;
-  label: string;
-  ext: string;
-  openLabel: string;
-}) {
-  const [mdHtml, setMdHtml] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState(false);
-  const [externalDiff, setExternalDiff] = useState<{
-    diff: string; linesAdded: number; linesRemoved: number; rollbackId?: string;
-  } | null>(null);
-  const [diffLoading, setDiffLoading] = useState(false);
-  const [diffError, setDiffError] = useState<string | null>(null);
-  const isMd = ext === 'md' || ext === 'markdown';
-  const isProse = isMd || ext === 'txt';
-  const isZh = String(document?.documentElement?.lang || '').startsWith('zh');
-
-  useEffect(() => {
-    if (!isMd) return;
-    let cancelled = false;
-    window.platform?.readFile?.(filePath)?.then((content: string | null) => {
-      if (cancelled || !content) return;
-      import('../../utils/markdown').then(({ renderMarkdown }) => {
-        if (!cancelled) setMdHtml(renderMarkdown(content));
-      });
-    });
-    return () => { cancelled = true; };
-  }, [filePath, isMd]);
-
-  const handleViewExternalDiff = useCallback(async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (diffLoading) return;
-    if (externalDiff) {
-      // 已显示则切换隐藏
-      setExternalDiff(null);
-      return;
-    }
-    setDiffLoading(true);
-    setDiffError(null);
-    try {
-      const res = await hanaFetch('/api/fs/external-diff', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ filePath }),
-      });
-      const data = await res.json();
-      if (!data.hasChanges) {
-        setDiffError(data.message || (isZh ? '无外部修改' : 'No external changes'));
-        return;
-      }
-      setExternalDiff({
-        diff: data.diff,
-        linesAdded: data.linesAdded,
-        linesRemoved: data.linesRemoved,
-        rollbackId: data.rollbackId,
-      });
-    } catch (err) {
-      const raw = err instanceof Error ? err.message : '';
-      setDiffError(raw.replace(/^hanaFetch\s+\S+:\s*/, '').trim() || (isZh ? '对比失败' : 'Diff failed'));
-    } finally {
-      setDiffLoading(false);
-    }
-  }, [diffLoading, externalDiff, filePath, isZh]);
-
-  return (
-    <div
-      className={styles.fileOutputCard}
-      style={isMd && mdHtml ? { flexDirection: 'column', alignItems: 'stretch', maxWidth: '100%' } : undefined}
-    >
-      <div className={styles.fileOutputHead}>
-        <span className={styles.fileOutputBadge}>{extLabel(ext)}</span>
-        <span className={styles.fileOutputLabel}>{label || filePath.split('/').pop() || filePath}</span>
-        <div className={styles.fileOutputActions}>
-          <button type="button" className={styles.fileOutputOpen} onClick={() => openFilePreview(filePath, label, ext)}>
-            {openLabel}
-          </button>
-          {isProse && (
-            <button
-              type="button"
-              className={styles.fileOutputOpen}
-              onClick={handleViewExternalDiff}
-              disabled={diffLoading}
-              title={isZh ? '对比 Git HEAD 以查看外部工具（如 Claude Code / VSCode）的修改' : 'Compare with git HEAD to view external edits'}
-            >
-              {diffLoading
-                ? (isZh ? '… 对比中' : '… Comparing')
-                : externalDiff
-                  ? (isZh ? '隐藏对比' : 'Hide diff')
-                  : (isZh ? '对比外部修改' : 'External diff')}
-            </button>
-          )}
-          {isMd && mdHtml && (
-            <button
-              type="button"
-              className={styles.fileOutputToggle}
-              onClick={(e) => { e.stopPropagation(); setCollapsed(c => !c); }}
-              aria-label={collapsed ? 'Expand preview' : 'Collapse preview'}
-            >
-              {collapsed ? '▶' : '▼'}
-            </button>
-          )}
-        </div>
-      </div>
-      <div className={styles.fileOutputPath}>{filePath}</div>
-      {diffError && (
-        <div style={{
-          marginTop: 8, padding: '6px 10px', fontSize: '0.78rem',
-          color: 'var(--text-muted)', background: 'var(--overlay-subtle, rgba(0,0,0,0.03))',
-          borderRadius: 4,
-        }}>{diffError}</div>
-      )}
-      {externalDiff && (
-        <div style={{ marginTop: 8 }}>
-          <Suspense fallback={null}>
-            <WritingDiffViewer
-              filePath={filePath}
-              diff={externalDiff.diff}
-              linesAdded={externalDiff.linesAdded}
-              linesRemoved={externalDiff.linesRemoved}
-              rollbackId={externalDiff.rollbackId}
-            />
-          </Suspense>
-        </div>
-      )}
-      {isMd && mdHtml && !collapsed && (
-        <div
-          className="md-content"
-          style={{
-            marginTop: '8px',
-            padding: '12px',
-            background: 'var(--bg-card, var(--bg))',
-            borderRadius: '6px',
-            border: '1px solid var(--overlay-light, rgba(0,0,0,0.06))',
-            fontSize: '0.88rem',
-            lineHeight: '1.6',
-            maxHeight: '400px',
-            overflowY: 'auto',
-            wordBreak: 'break-word',
-          }}
-          dangerouslySetInnerHTML={{ __html: mdHtml }}
-        />
-      )}
-    </div>
-  );
-}
-
-function ArtifactCard({ title, artifactType, artifactId, content, language }: {
-  title: string;
-  artifactType: string;
-  artifactId: string;
-  content: string;
-  language?: string;
-}) {
-  const t = window.t ?? ((p: string) => p);
-  const handleOpenPreview = () => openPreview({ id: artifactId, type: artifactType as any, title, content, language });
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.target !== event.currentTarget) return;
-    if (event.key !== 'Enter' && event.key !== ' ') return;
-    event.preventDefault();
-    handleOpenPreview();
-  };
-
-  return (
-    <div
-      className={styles.fileOutputCard}
-      style={{ cursor: 'pointer' }}
-      role="button"
-      tabIndex={0}
-      onClick={handleOpenPreview}
-      onKeyDown={handleKeyDown}
-    >
-      <div className={styles.fileOutputHead}>
-        <span className={styles.fileOutputBadge}>{artifactType.toUpperCase()}</span>
-        <span className={styles.fileOutputLabel}>{title}</span>
-        {artifactType === 'html' && (
-          <div className={styles.fileOutputActions}>
-            <button
-              type="button"
-              className={styles.fileOutputOpen}
-              onClick={(e) => { e.stopPropagation(); window.platform?.openHtmlInBrowser?.(content, title); }}
-            >
-              {t('preview.openInBrowser')}
-            </button>
-            <button
-              type="button"
-              className={styles.fileOutputOpen}
-              onClick={async (e) => {
-                e.stopPropagation();
-                if (!window.platform?.exportHtmlToPng) return;
-                const result = await window.platform.exportHtmlToPng(content, title);
-                if (!result?.filePath) {
-                  // Web 降级或失败 — 静默,等后续可加 toast
-                  return;
-                }
-                // 已自动 showItemInFolder 在 main 侧
-              }}
-            >
-              {t('preview.exportPng')}
-            </button>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function BrowserScreenshot({ base64, mimeType }: { base64: string; mimeType: string }) {
-  return <ImageBlock className={styles.browserShot} src={`data:${mimeType};base64,${base64}`} alt="Browser Screenshot" />;
-}
-
-function SkillCard({ skillName, skillFilePath }: { skillName: string; skillFilePath: string }) {
-  return (
-    <button
-      className={styles.fileOutputCard}
-      onClick={() => openSkillPreview(skillName, skillFilePath)}
-    >
-      <div className={styles.fileOutputHead}>
-        <span className={styles.fileOutputBadge}>SKILL</span>
-        <span className={styles.fileOutputLabel}>{skillName}</span>
-      </div>
-      <div className={styles.fileOutputPath}>{skillFilePath}</div>
-    </button>
-  );
-}
-
-function CronConfirmCard({ confirmId, jobData, status }: { confirmId?: string; jobData: any; status: string }) {
-  const { t } = useI18n();
-  const addToast = useStore((s) => s.addToast);
-  const [submitting, setSubmitting] = useState(false);
-
-  const sendDecision = useCallback(async (action: 'approved' | 'rejected') => {
-    if (!confirmId || submitting) return;
-    setSubmitting(true);
-    try {
-      await hanaFetch(`/api/cron/confirm/${confirmId}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action }),
-      });
-      addToast(action === 'approved' ? t('common.saved') : t('common.cancelled'), 'success');
-    } catch (err) {
-      addToast(err instanceof Error ? err.message : String(err), 'error');
-    } finally {
-      setSubmitting(false);
-    }
-  }, [addToast, confirmId, submitting, t]);
-
-  return (
-    <div className={styles.cronConfirmCard}>
-      <div className={styles.cronConfirmTitle}>{jobData.label || t('cron.confirm.title')}</div>
-      <div className={styles.cronConfirmMeta}>{jobData.schedule}</div>
-      <div className={styles.cronConfirmPrompt}>{jobData.prompt}</div>
-      {status === 'pending' && confirmId && (
-        <div className={styles.cronConfirmActions}>
-          <button onClick={() => sendDecision('rejected')} disabled={submitting}>{t('common.cancel')}</button>
-          <button onClick={() => sendDecision('approved')} disabled={submitting}>{t('common.confirm')}</button>
-        </div>
-      )}
-    </div>
-  );
-}

--- a/desktop/src/react/components/chat/MessageCards.tsx
+++ b/desktop/src/react/components/chat/MessageCards.tsx
@@ -1,0 +1,284 @@
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
+import { ImageBlock } from './ImageBlock';
+import { hanaFetch } from '../../hooks/use-hana-fetch';
+import { useI18n } from '../../hooks/use-i18n';
+import { useStore } from '../../stores';
+import { openPreview } from '../../stores/artifact-actions';
+import { openFilePreview, openSkillPreview } from '../../utils/file-preview';
+import styles from './Chat.module.css';
+
+const WritingDiffViewer = lazy(() => import('./WritingDiffViewer').then((m) => ({ default: m.WritingDiffViewer })));
+
+const EXT_LABELS: Record<string, string> = {
+  pdf: 'PDF', doc: 'Word', docx: 'Word', xls: 'Excel', xlsx: 'Excel',
+  ppt: 'Presentation', pptx: 'Presentation', md: 'Markdown', txt: 'Text',
+  html: 'HTML', htm: 'HTML', css: 'Stylesheet', json: 'JSON', yaml: 'YAML', yml: 'YAML',
+};
+
+function extLabel(ext: string): string {
+  return EXT_LABELS[ext.toLowerCase()] || ext.toUpperCase();
+}
+
+export function FileOutputCard({
+  filePath,
+  label,
+  ext,
+  openLabel,
+}: {
+  filePath: string;
+  label: string;
+  ext: string;
+  openLabel: string;
+}) {
+  const [mdHtml, setMdHtml] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
+  const [externalDiff, setExternalDiff] = useState<{
+    diff: string; linesAdded: number; linesRemoved: number; rollbackId?: string;
+  } | null>(null);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const [diffError, setDiffError] = useState<string | null>(null);
+  const isMd = ext === 'md' || ext === 'markdown';
+  const isProse = isMd || ext === 'txt';
+  const isZh = String(document?.documentElement?.lang || '').startsWith('zh');
+
+  useEffect(() => {
+    if (!isMd) return;
+    let cancelled = false;
+    window.platform?.readFile?.(filePath)?.then((content: string | null) => {
+      if (cancelled || !content) return;
+      import('../../utils/markdown').then(({ renderMarkdown }) => {
+        if (!cancelled) setMdHtml(renderMarkdown(content));
+      });
+    });
+    return () => { cancelled = true; };
+  }, [filePath, isMd]);
+
+  const handleViewExternalDiff = useCallback(async (e: ReactMouseEvent) => {
+    e.stopPropagation();
+    if (diffLoading) return;
+    if (externalDiff) {
+      setExternalDiff(null);
+      return;
+    }
+    setDiffLoading(true);
+    setDiffError(null);
+    try {
+      const res = await hanaFetch('/api/fs/external-diff', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filePath }),
+      });
+      const data = await res.json();
+      if (!data.hasChanges) {
+        setDiffError(data.message || (isZh ? '无外部修改' : 'No external changes'));
+        return;
+      }
+      setExternalDiff({
+        diff: data.diff,
+        linesAdded: data.linesAdded,
+        linesRemoved: data.linesRemoved,
+        rollbackId: data.rollbackId,
+      });
+    } catch (err) {
+      const raw = err instanceof Error ? err.message : '';
+      setDiffError(raw.replace(/^hanaFetch\s+\S+:\s*/, '').trim() || (isZh ? '对比失败' : 'Diff failed'));
+    } finally {
+      setDiffLoading(false);
+    }
+  }, [diffLoading, externalDiff, filePath, isZh]);
+
+  return (
+    <div
+      className={styles.fileOutputCard}
+      style={isMd && mdHtml ? { flexDirection: 'column', alignItems: 'stretch', maxWidth: '100%' } : undefined}
+    >
+      <div className={styles.fileOutputHead}>
+        <span className={styles.fileOutputBadge}>{extLabel(ext)}</span>
+        <span className={styles.fileOutputLabel}>{label || filePath.split('/').pop() || filePath}</span>
+        <div className={styles.fileOutputActions}>
+          <button type="button" className={styles.fileOutputOpen} onClick={() => openFilePreview(filePath, label, ext)}>
+            {openLabel}
+          </button>
+          {isProse && (
+            <button
+              type="button"
+              className={styles.fileOutputOpen}
+              onClick={handleViewExternalDiff}
+              disabled={diffLoading}
+              title={isZh ? '对比 Git HEAD 以查看外部工具（如 Claude Code / VSCode）的修改' : 'Compare with git HEAD to view external edits'}
+            >
+              {diffLoading
+                ? (isZh ? '… 对比中' : '… Comparing')
+                : externalDiff
+                  ? (isZh ? '隐藏对比' : 'Hide diff')
+                  : (isZh ? '对比外部修改' : 'External diff')}
+            </button>
+          )}
+          {isMd && mdHtml && (
+            <button
+              type="button"
+              className={styles.fileOutputToggle}
+              onClick={(e) => { e.stopPropagation(); setCollapsed(c => !c); }}
+              aria-label={collapsed ? 'Expand preview' : 'Collapse preview'}
+            >
+              {collapsed ? '▶' : '▼'}
+            </button>
+          )}
+        </div>
+      </div>
+      <div className={styles.fileOutputPath}>{filePath}</div>
+      {diffError && (
+        <div style={{
+          marginTop: 8, padding: '6px 10px', fontSize: '0.78rem',
+          color: 'var(--text-muted)', background: 'var(--overlay-subtle, rgba(0,0,0,0.03))',
+          borderRadius: 4,
+        }}>{diffError}</div>
+      )}
+      {externalDiff && (
+        <div style={{ marginTop: 8 }}>
+          <Suspense fallback={null}>
+            <WritingDiffViewer
+              filePath={filePath}
+              diff={externalDiff.diff}
+              linesAdded={externalDiff.linesAdded}
+              linesRemoved={externalDiff.linesRemoved}
+              rollbackId={externalDiff.rollbackId}
+            />
+          </Suspense>
+        </div>
+      )}
+      {isMd && mdHtml && !collapsed && (
+        <div
+          className="md-content"
+          style={{
+            marginTop: '8px',
+            padding: '12px',
+            background: 'var(--bg-card, var(--bg))',
+            borderRadius: '6px',
+            border: '1px solid var(--overlay-light, rgba(0,0,0,0.06))',
+            fontSize: '0.88rem',
+            lineHeight: '1.6',
+            maxHeight: '400px',
+            overflowY: 'auto',
+            wordBreak: 'break-word',
+          }}
+          dangerouslySetInnerHTML={{ __html: mdHtml }}
+        />
+      )}
+    </div>
+  );
+}
+
+export function ArtifactCard({ title, artifactType, artifactId, content, language }: {
+  title: string;
+  artifactType: string;
+  artifactId: string;
+  content: string;
+  language?: string;
+}) {
+  const t = window.t ?? ((p: string) => p);
+  const handleOpenPreview = () => openPreview({ id: artifactId, type: artifactType as any, title, content, language });
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    handleOpenPreview();
+  };
+
+  return (
+    <div
+      className={styles.fileOutputCard}
+      style={{ cursor: 'pointer' }}
+      role="button"
+      tabIndex={0}
+      onClick={handleOpenPreview}
+      onKeyDown={handleKeyDown}
+    >
+      <div className={styles.fileOutputHead}>
+        <span className={styles.fileOutputBadge}>{artifactType.toUpperCase()}</span>
+        <span className={styles.fileOutputLabel}>{title}</span>
+        {artifactType === 'html' && (
+          <div className={styles.fileOutputActions}>
+            <button
+              type="button"
+              className={styles.fileOutputOpen}
+              onClick={(e) => { e.stopPropagation(); window.platform?.openHtmlInBrowser?.(content, title); }}
+            >
+              {t('preview.openInBrowser')}
+            </button>
+            <button
+              type="button"
+              className={styles.fileOutputOpen}
+              onClick={async (e) => {
+                e.stopPropagation();
+                if (!window.platform?.exportHtmlToPng) return;
+                const result = await window.platform.exportHtmlToPng(content, title);
+                if (!result?.filePath) return;
+              }}
+            >
+              {t('preview.exportPng')}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function BrowserScreenshot({ base64, mimeType }: { base64: string; mimeType: string }) {
+  return <ImageBlock className={styles.browserShot} src={`data:${mimeType};base64,${base64}`} alt="Browser Screenshot" />;
+}
+
+export function SkillCard({ skillName, skillFilePath }: { skillName: string; skillFilePath: string }) {
+  return (
+    <button
+      type="button"
+      className={styles.fileOutputCard}
+      onClick={() => openSkillPreview(skillName, skillFilePath)}
+    >
+      <div className={styles.fileOutputHead}>
+        <span className={styles.fileOutputBadge}>SKILL</span>
+        <span className={styles.fileOutputLabel}>{skillName}</span>
+      </div>
+      <div className={styles.fileOutputPath}>{skillFilePath}</div>
+    </button>
+  );
+}
+
+export function CronConfirmCard({ confirmId, jobData, status }: { confirmId?: string; jobData: any; status: string }) {
+  const { t } = useI18n();
+  const addToast = useStore((s) => s.addToast);
+  const [submitting, setSubmitting] = useState(false);
+
+  const sendDecision = useCallback(async (action: 'approved' | 'rejected') => {
+    if (!confirmId || submitting) return;
+    setSubmitting(true);
+    try {
+      await hanaFetch(`/api/cron/confirm/${confirmId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action }),
+      });
+      addToast(action === 'approved' ? t('common.saved') : t('common.cancelled'), 'success');
+    } catch (err) {
+      addToast(err instanceof Error ? err.message : String(err), 'error');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [addToast, confirmId, submitting, t]);
+
+  return (
+    <div className={styles.cronConfirmCard}>
+      <div className={styles.cronConfirmTitle}>{jobData.label || t('cron.confirm.title')}</div>
+      <div className={styles.cronConfirmMeta}>{jobData.schedule}</div>
+      <div className={styles.cronConfirmPrompt}>{jobData.prompt}</div>
+      {status === 'pending' && confirmId && (
+        <div className={styles.cronConfirmActions}>
+          <button type="button" onClick={() => sendDecision('rejected')} disabled={submitting}>{t('common.cancel')}</button>
+          <button type="button" onClick={() => sendDecision('approved')} disabled={submitting}>{t('common.confirm')}</button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- move file output, artifact, screenshot, skill, and cron-confirm card renderers out of `AssistantMessage.tsx`
- keep message orchestration in `AssistantMessage` while colocating card-specific state/effects in `MessageCards.tsx`
- add `type=button` to moved card buttons to avoid accidental submit behavior in future containers

## Impact
- `AssistantMessage.tsx` shrinks from 1091 lines to 812 lines
- no behavior or styling changes intended

## Validation
- `npm run typecheck`
- `npm run build:renderer`
- `npm test -- --reporter=dot desktop/src/react/__tests__ tests/chat-route-events.test.js`
- `npm run release:gate`

No local model/model-data assets were downloaded.