### PR TITLE
refactor(automation): extract cron utils

### DIFF
--- a/desktop/src/react/__tests__/automation-cron-utils.test.ts
+++ b/desktop/src/react/__tests__/automation-cron-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCron,
+  buildScheduleFromPreset,
+  formatAutomationDateTime,
+  inferSchedulePreset,
+  parseCronDays,
+  parseCronTime,
+} from '../components/automation/cron-utils';
+
+describe('automation cron utils', () => {
+  it('parses cron time and weekdays', () => {
+    expect(parseCronTime('30 9 * * 1-5')).toEqual({ hour: '09', minute: '30' });
+    expect(parseCronDays('30 9 * * 1-5')).toEqual([1, 2, 3, 4, 5]);
+    expect(parseCronDays('0 18 * * *')).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  it('infers schedule presets from cron day fields', () => {
+    expect(inferSchedulePreset('0 9 * * *')).toBe('daily');
+    expect(inferSchedulePreset('0 9 * * 1,2,3,4,5')).toBe('weekdays');
+    expect(inferSchedulePreset('0 9 * * 5')).toBe('weekly');
+    expect(inferSchedulePreset('0 9 * * 1,3,5')).toBe('custom');
+  });
+
+  it('builds cron expressions from presets', () => {
+    expect(buildCron('09', '30', [])).toBe('30 9 * * *');
+    expect(buildScheduleFromPreset('daily', '09', '30', 5, [])).toBe('30 9 * * *');
+    expect(buildScheduleFromPreset('weekdays', '09', '30', 5, [])).toBe('30 9 * * 1,2,3,4,5');
+    expect(buildScheduleFromPreset('weekly', '18', '00', 5, [])).toBe('0 18 * * 5');
+    expect(buildScheduleFromPreset('custom', '11', '05', 5, [1, 3])).toBe('5 11 * * 1,3');
+  });
+
+  it('formats automation dates with a provided locale', () => {
+    expect(formatAutomationDateTime('2026-05-28T09:30:00Z', 'en-US')).toContain('5/28');
+    expect(formatAutomationDateTime(null, 'en-US')).toBe('');
+  });
+});

--- a/desktop/src/react/components/AutomationPanel.tsx
+++ b/desktop/src/react/components/AutomationPanel.tsx
@@ -7,6 +7,14 @@ import {
   normalizeDisplayModelName,
   normalizeDisplayProviderLabel,
 } from '../utils/brain-models';
+import {
+  buildScheduleFromPreset,
+  formatAutomationDateTime,
+  inferSchedulePreset,
+  parseCronDays,
+  parseCronTime,
+  type SchedulePreset,
+} from './automation/cron-utils';
 import fp from './FloatingPanels.module.css';
 
 interface CronJob {
@@ -47,7 +55,6 @@ interface ModelOption {
 }
 
 type AutomationCategory = 'reports' | 'organize' | 'followup';
-type SchedulePreset = 'daily' | 'weekdays' | 'weekly' | 'custom';
 
 interface TemplateDefinition {
   id: string;
@@ -70,7 +77,6 @@ interface TemplateDefinition {
 
 const DAY_KEYS = ['日', '一', '二', '三', '四', '五', '六'];
 const DAY_KEYS_EN = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-const WEEKDAY_SET = '1,2,3,4,5';
 
 const TEMPLATES: TemplateDefinition[] = [
   {
@@ -234,77 +240,6 @@ function folderLabel(folderPath: string | null): string {
   if (!folderPath) return '';
   const parts = folderPath.split(/[\\/]+/).filter(Boolean);
   return parts[parts.length - 1] || folderPath;
-}
-
-function formatAutomationDateTime(ts?: string | number | null): string {
-  if (!ts) return '';
-  try {
-    return new Date(ts).toLocaleString(String(window.i18n?.locale || 'zh-CN'), {
-      month: 'numeric',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  } catch {
-    return '';
-  }
-}
-
-function parseCronTime(schedule: string | number): { hour: string; minute: string } | null {
-  if (typeof schedule !== 'string') return null;
-  const parts = String(schedule).split(' ');
-  if (parts.length !== 5) return null;
-  const [min, hour] = parts;
-  if (hour === '*' || min === '*') return null;
-  return {
-    hour: String(parseInt(hour, 10)).padStart(2, '0'),
-    minute: String(parseInt(min, 10)).padStart(2, '0'),
-  };
-}
-
-function parseCronDays(schedule: string | number): number[] {
-  if (typeof schedule !== 'string') return [];
-  const parts = String(schedule).split(' ');
-  if (parts.length !== 5) return [];
-  const dow = String(parts[4] || '').trim();
-  if (!dow || dow === '*') return [0, 1, 2, 3, 4, 5, 6];
-  if (dow === '1-5') return [1, 2, 3, 4, 5];
-  return dow
-    .split(',')
-    .map((value) => parseInt(value, 10))
-    .filter((value) => !Number.isNaN(value) && value >= 0 && value <= 6);
-}
-
-function inferSchedulePreset(schedule: string | number): SchedulePreset {
-  if (typeof schedule !== 'string') return 'custom';
-  const parts = String(schedule).split(' ');
-  if (parts.length !== 5) return 'custom';
-  const dow = String(parts[4] || '').trim();
-  if (!dow || dow === '*') return 'daily';
-  if (dow === '1-5' || dow === WEEKDAY_SET) return 'weekdays';
-  if (/^\d$/.test(dow)) return 'weekly';
-  return 'custom';
-}
-
-function buildCron(hour: string, minute: string, days: number[]): string {
-  const normalizedHour = String(parseInt(hour || '9', 10)).padStart(2, '0');
-  const normalizedMinute = String(parseInt(minute || '0', 10)).padStart(2, '0');
-  const uniqueDays = Array.from(new Set(days)).sort((left, right) => left - right);
-  const dowPart = uniqueDays.length === 0 || uniqueDays.length === 7 ? '*' : uniqueDays.join(',');
-  return `${parseInt(normalizedMinute, 10)} ${parseInt(normalizedHour, 10)} * * ${dowPart}`;
-}
-
-function buildScheduleFromPreset(
-  preset: SchedulePreset,
-  hour: string,
-  minute: string,
-  weeklyDay: number,
-  customDays: number[],
-): string {
-  if (preset === 'daily') return buildCron(hour, minute, []);
-  if (preset === 'weekdays') return buildCron(hour, minute, [1, 2, 3, 4, 5]);
-  if (preset === 'weekly') return buildCron(hour, minute, [weeklyDay]);
-  return buildCron(hour, minute, customDays.length > 0 ? customDays : [1]);
 }
 
 function DaySelector({

--- a/desktop/src/react/components/automation/cron-utils.ts
+++ b/desktop/src/react/components/automation/cron-utils.ts
@@ -1,0 +1,77 @@
+export type SchedulePreset = 'daily' | 'weekdays' | 'weekly' | 'custom';
+
+const WEEKDAY_SET = '1,2,3,4,5';
+
+export function formatAutomationDateTime(
+  ts?: string | number | null,
+  locale = String(window.i18n?.locale || 'zh-CN'),
+): string {
+  if (!ts) return '';
+  try {
+    return new Date(ts).toLocaleString(locale, {
+      month: 'numeric',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
+}
+
+export function parseCronTime(schedule: string | number): { hour: string; minute: string } | null {
+  if (typeof schedule !== 'string') return null;
+  const parts = String(schedule).split(' ');
+  if (parts.length !== 5) return null;
+  const [min, hour] = parts;
+  if (hour === '*' || min === '*') return null;
+  return {
+    hour: String(parseInt(hour, 10)).padStart(2, '0'),
+    minute: String(parseInt(min, 10)).padStart(2, '0'),
+  };
+}
+
+export function parseCronDays(schedule: string | number): number[] {
+  if (typeof schedule !== 'string') return [];
+  const parts = String(schedule).split(' ');
+  if (parts.length !== 5) return [];
+  const dow = String(parts[4] || '').trim();
+  if (!dow || dow === '*') return [0, 1, 2, 3, 4, 5, 6];
+  if (dow === '1-5') return [1, 2, 3, 4, 5];
+  return dow
+    .split(',')
+    .map((value) => parseInt(value, 10))
+    .filter((value) => !Number.isNaN(value) && value >= 0 && value <= 6);
+}
+
+export function inferSchedulePreset(schedule: string | number): SchedulePreset {
+  if (typeof schedule !== 'string') return 'custom';
+  const parts = String(schedule).split(' ');
+  if (parts.length !== 5) return 'custom';
+  const dow = String(parts[4] || '').trim();
+  if (!dow || dow === '*') return 'daily';
+  if (dow === '1-5' || dow === WEEKDAY_SET) return 'weekdays';
+  if (/^\d$/.test(dow)) return 'weekly';
+  return 'custom';
+}
+
+export function buildCron(hour: string, minute: string, days: number[]): string {
+  const normalizedHour = String(parseInt(hour || '9', 10)).padStart(2, '0');
+  const normalizedMinute = String(parseInt(minute || '0', 10)).padStart(2, '0');
+  const uniqueDays = Array.from(new Set(days)).sort((left, right) => left - right);
+  const dowPart = uniqueDays.length === 0 || uniqueDays.length === 7 ? '*' : uniqueDays.join(',');
+  return `${parseInt(normalizedMinute, 10)} ${parseInt(normalizedHour, 10)} * * ${dowPart}`;
+}
+
+export function buildScheduleFromPreset(
+  preset: SchedulePreset,
+  hour: string,
+  minute: string,
+  weeklyDay: number,
+  customDays: number[],
+): string {
+  if (preset === 'daily') return buildCron(hour, minute, []);
+  if (preset === 'weekdays') return buildCron(hour, minute, [1, 2, 3, 4, 5]);
+  if (preset === 'weekly') return buildCron(hour, minute, [weeklyDay]);
+  return buildCron(hour, minute, customDays.length > 0 ? customDays : [1]);
+}


### PR DESCRIPTION
## Summary
- move automation cron parsing, preset inference, schedule building, and date formatting into `components/automation/cron-utils.ts`
- add dedicated unit coverage for cron parsing/preset/build helpers
- reduce `AutomationPanel.tsx` from 1172 to 1107 lines without changing UI behavior

## Validation
- `npm run typecheck`
- `npm test -- --reporter=dot desktop/src/react/__tests__/automation-cron-utils.test.ts`
- `npm run release:gate`

No local model/model-data assets were downloaded.