### PR TITLE
refactor(automation): extract job card

### DIFF
--- a/desktop/src/react/components/AutomationPanel.tsx
+++ b/desktop/src/react/components/AutomationPanel.tsx
@@ -1,58 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useStore } from '../stores';
 import { hanaFetch } from '../hooks/use-hana-fetch';
-import { cronToHuman } from '../utils/format';
 import {
   collapseBrainModelChoices,
   normalizeDisplayModelName,
   normalizeDisplayProviderLabel,
 } from '../utils/brain-models';
+import { AutomationJobCard } from './automation/AutomationJobCard';
 import {
   buildScheduleFromPreset,
-  formatAutomationDateTime,
   inferSchedulePreset,
   parseCronDays,
   parseCronTime,
   type SchedulePreset,
 } from './automation/cron-utils';
+import { folderLabel, resolveJobModelValue } from './automation/job-utils';
+import type { CronJob, ModelOption } from './automation/types';
 import fp from './FloatingPanels.module.css';
-
-interface CronJob {
-  id: string;
-  enabled: boolean;
-  label?: string;
-  prompt?: string;
-  schedule: string | number;
-  model?: string;
-  workspace?: string;
-  nextRunAt?: string | null;
-  lastRunAt?: string | null;
-  latestRun?: {
-    status?: string;
-    startedAt?: string;
-    finishedAt?: string;
-    error?: string;
-    timestamp?: string;
-  } | null;
-  latestActivity?: {
-    id?: string;
-    summary?: string;
-    status?: string;
-    error?: string | null;
-    startedAt?: number | null;
-    finishedAt?: number | null;
-    sessionFile?: string | null;
-    outputFile?: string | null;
-    workspace?: string;
-  } | null;
-}
-
-interface ModelOption {
-  value: string;
-  label: string;
-  rawId: string;
-  rawProvider: string;
-}
 
 type AutomationCategory = 'reports' | 'organize' | 'followup';
 
@@ -227,21 +191,6 @@ function buildAutomationModelOptions(models: Array<{ id: string; name?: string; 
   });
 }
 
-function resolveJobModelValue(modelRef: string | undefined, options: ModelOption[]): string {
-  const raw = String(modelRef || '').trim();
-  if (!raw) return '';
-  const exact = options.find((option) => option.value === raw);
-  if (exact) return exact.value;
-  const byRawId = options.find((option) => option.rawId === raw);
-  return byRawId?.value || raw;
-}
-
-function folderLabel(folderPath: string | null): string {
-  if (!folderPath) return '';
-  const parts = folderPath.split(/[\\/]+/).filter(Boolean);
-  return parts[parts.length - 1] || folderPath;
-}
-
 function DaySelector({
   selected,
   single = false,
@@ -327,119 +276,6 @@ function TimePicker({
 
 function updateBadge(jobs: CronJob[]) {
   useStore.setState({ automationCount: jobs.length });
-}
-
-function AutomationJobCard({
-  job,
-  modelOptions,
-  isZh,
-  defaultModelLabel,
-  onToggle,
-  onEdit,
-  onRemove,
-  onRunNow,
-}: {
-  job: CronJob;
-  modelOptions: ModelOption[];
-  isZh: boolean;
-  defaultModelLabel: string;
-  onToggle: (id: string) => void;
-  onEdit: (job: CronJob) => void;
-  onRemove: (id: string) => void;
-  onRunNow: (id: string) => void;
-}) {
-  const selectedValue = resolveJobModelValue(job.model, modelOptions);
-  const modelLabel = selectedValue
-    ? modelOptions.find((option) => option.value === selectedValue)?.label || job.model || ''
-    : defaultModelLabel;
-  const workspaceLabel = folderLabel(job.workspace || null);
-  const nextRunText = formatAutomationDateTime(job.nextRunAt || null);
-  const lastRunText = formatAutomationDateTime(job.lastRunAt || job.latestRun?.finishedAt || job.latestRun?.timestamp || null);
-  const latestRunStatus = String(job.latestRun?.status || job.latestActivity?.status || '').trim();
-  const latestSummary = String(job.latestActivity?.summary || '').trim();
-  const latestError = String(job.latestRun?.error || job.latestActivity?.error || '').trim();
-  const hasRunRecord = Boolean(job.lastRunAt || job.latestRun || job.latestActivity);
-  const statusLabel = latestRunStatus === 'success'
-    ? (isZh ? '最近一次已完成' : 'Last run completed')
-    : latestRunStatus === 'error'
-      ? (isZh ? '最近一次失败' : 'Last run failed')
-      : latestRunStatus === 'skipped'
-        ? (isZh ? '最近一次跳过' : 'Last run skipped')
-        : '';
-
-  const openLatestResult = () => {
-    const activityId = String(job.latestActivity?.id || '').trim();
-    if (!activityId) return;
-    window.dispatchEvent(new CustomEvent('hana-open-activity-session', { detail: { activityId } }));
-  };
-
-  const openLatestFile = () => {
-    const filePath = String(job.latestActivity?.outputFile || '').trim();
-    if (!filePath) return;
-    window.platform?.openFile?.(filePath);
-  };
-
-  return (
-    <div className={fp.automationJobCard}>
-      <div className={fp.automationJobHead}>
-        <div className={fp.automationJobTitle}>{job.label || job.prompt || job.id}</div>
-        <button
-          type="button"
-          className={`${fp.automationJobSwitch}${job.enabled ? ` ${fp.automationJobSwitchOn}` : ''}`}
-          onClick={() => onToggle(job.id)}
-        >
-          {job.enabled ? (isZh ? '已开启' : 'On') : (isZh ? '已暂停' : 'Paused')}
-        </button>
-      </div>
-      <div className={fp.automationJobDesc}>{job.prompt || (isZh ? '暂无说明' : 'No description')}</div>
-      <div className={fp.automationJobMeta}>
-        <span className={fp.automationJobMetaChip}>{cronToHuman(job.schedule)}</span>
-        <span className={fp.automationJobMetaChip}>{modelLabel}</span>
-        {workspaceLabel ? <span className={fp.automationJobMetaChip}>{workspaceLabel}</span> : null}
-        {nextRunText ? <span className={fp.automationJobMetaChip}>{isZh ? `下次 ${nextRunText}` : `Next ${nextRunText}`}</span> : null}
-        {lastRunText ? <span className={fp.automationJobMetaChip}>{isZh ? `上次 ${lastRunText}` : `Last ${lastRunText}`}</span> : null}
-      </div>
-      {(statusLabel || latestSummary || latestError || !hasRunRecord) && (
-        <div className={fp.automationJobResult}>
-          {statusLabel ? <div className={fp.automationJobResultTitle}>{statusLabel}</div> : null}
-          {latestSummary ? <div className={fp.automationJobResultSummary}>{latestSummary}</div> : null}
-          {!latestSummary && latestError ? <div className={fp.automationJobResultError}>{latestError}</div> : null}
-          {!latestSummary && !latestError && (statusLabel || !hasRunRecord) ? (
-            <div className={fp.automationJobResultHint}>
-              {hasRunRecord
-                ? (isZh ? '结果会出现在活动记录里，并自动写入工作区里的 “Lynn-自动任务结果” 文件夹。' : 'Results appear in Activity and are also written into the workspace result folder.')
-                : (isZh ? '还没有执行记录。到点后结果会出现在活动记录里，并自动写入工作区里的 “Lynn-自动任务结果” 文件夹。' : 'No run yet. When the task fires, the result will appear in Activity and in the workspace result folder.')}
-            </div>
-          ) : null}
-        </div>
-      )}
-      <div className={fp.automationJobActions}>
-        <button type="button" className={fp.automationLinkBtn} onClick={() => onRunNow(job.id)}>
-          {isZh ? '立即执行' : 'Run now'}
-        </button>
-        {job.latestActivity?.outputFile ? (
-          <button type="button" className={fp.automationLinkBtn} onClick={openLatestFile}>
-            {isZh ? '打开文件' : 'Open file'}
-          </button>
-        ) : null}
-        {job.latestActivity?.id ? (
-          <button type="button" className={fp.automationLinkBtn} onClick={openLatestResult}>
-            {isZh ? '查看结果' : 'Open result'}
-          </button>
-        ) : null}
-        <button type="button" className={fp.automationLinkBtn} onClick={() => onEdit(job)}>
-          {isZh ? '编辑' : 'Edit'}
-        </button>
-        <button
-          type="button"
-          className={`${fp.automationLinkBtn} ${fp.automationDangerBtn}`}
-          onClick={() => onRemove(job.id)}
-        >
-          {isZh ? '删除' : 'Delete'}
-        </button>
-      </div>
-    </div>
-  );
 }
 
 export function AutomationPanel() {

--- a/desktop/src/react/components/automation/AutomationJobCard.tsx
+++ b/desktop/src/react/components/automation/AutomationJobCard.tsx
@@ -1,0 +1,118 @@
+import { cronToHuman } from '../../utils/format';
+import fp from '../FloatingPanels.module.css';
+import { formatAutomationDateTime } from './cron-utils';
+import { folderLabel, resolveJobModelValue } from './job-utils';
+import type { CronJob, ModelOption } from './types';
+
+export function AutomationJobCard({
+  job,
+  modelOptions,
+  isZh,
+  defaultModelLabel,
+  onToggle,
+  onEdit,
+  onRemove,
+  onRunNow,
+}: {
+  job: CronJob;
+  modelOptions: ModelOption[];
+  isZh: boolean;
+  defaultModelLabel: string;
+  onToggle: (id: string) => void;
+  onEdit: (job: CronJob) => void;
+  onRemove: (id: string) => void;
+  onRunNow: (id: string) => void;
+}) {
+  const selectedValue = resolveJobModelValue(job.model, modelOptions);
+  const modelLabel = selectedValue
+    ? modelOptions.find((option) => option.value === selectedValue)?.label || job.model || ''
+    : defaultModelLabel;
+  const workspaceLabel = folderLabel(job.workspace || null);
+  const nextRunText = formatAutomationDateTime(job.nextRunAt || null);
+  const lastRunText = formatAutomationDateTime(job.lastRunAt || job.latestRun?.finishedAt || job.latestRun?.timestamp || null);
+  const latestRunStatus = String(job.latestRun?.status || job.latestActivity?.status || '').trim();
+  const latestSummary = String(job.latestActivity?.summary || '').trim();
+  const latestError = String(job.latestRun?.error || job.latestActivity?.error || '').trim();
+  const hasRunRecord = Boolean(job.lastRunAt || job.latestRun || job.latestActivity);
+  const statusLabel = latestRunStatus === 'success'
+    ? (isZh ? '最近一次已完成' : 'Last run completed')
+    : latestRunStatus === 'error'
+      ? (isZh ? '最近一次失败' : 'Last run failed')
+      : latestRunStatus === 'skipped'
+        ? (isZh ? '最近一次跳过' : 'Last run skipped')
+        : '';
+
+  const openLatestResult = () => {
+    const activityId = String(job.latestActivity?.id || '').trim();
+    if (!activityId) return;
+    window.dispatchEvent(new CustomEvent('hana-open-activity-session', { detail: { activityId } }));
+  };
+
+  const openLatestFile = () => {
+    const filePath = String(job.latestActivity?.outputFile || '').trim();
+    if (!filePath) return;
+    window.platform?.openFile?.(filePath);
+  };
+
+  return (
+    <div className={fp.automationJobCard}>
+      <div className={fp.automationJobHead}>
+        <div className={fp.automationJobTitle}>{job.label || job.prompt || job.id}</div>
+        <button
+          type="button"
+          className={`${fp.automationJobSwitch}${job.enabled ? ` ${fp.automationJobSwitchOn}` : ''}`}
+          onClick={() => onToggle(job.id)}
+        >
+          {job.enabled ? (isZh ? '已开启' : 'On') : (isZh ? '已暂停' : 'Paused')}
+        </button>
+      </div>
+      <div className={fp.automationJobDesc}>{job.prompt || (isZh ? '暂无说明' : 'No description')}</div>
+      <div className={fp.automationJobMeta}>
+        <span className={fp.automationJobMetaChip}>{cronToHuman(job.schedule)}</span>
+        <span className={fp.automationJobMetaChip}>{modelLabel}</span>
+        {workspaceLabel ? <span className={fp.automationJobMetaChip}>{workspaceLabel}</span> : null}
+        {nextRunText ? <span className={fp.automationJobMetaChip}>{isZh ? `下次 ${nextRunText}` : `Next ${nextRunText}`}</span> : null}
+        {lastRunText ? <span className={fp.automationJobMetaChip}>{isZh ? `上次 ${lastRunText}` : `Last ${lastRunText}`}</span> : null}
+      </div>
+      {(statusLabel || latestSummary || latestError || !hasRunRecord) && (
+        <div className={fp.automationJobResult}>
+          {statusLabel ? <div className={fp.automationJobResultTitle}>{statusLabel}</div> : null}
+          {latestSummary ? <div className={fp.automationJobResultSummary}>{latestSummary}</div> : null}
+          {!latestSummary && latestError ? <div className={fp.automationJobResultError}>{latestError}</div> : null}
+          {!latestSummary && !latestError && (statusLabel || !hasRunRecord) ? (
+            <div className={fp.automationJobResultHint}>
+              {hasRunRecord
+                ? (isZh ? '结果会出现在活动记录里，并自动写入工作区里的 “Lynn-自动任务结果” 文件夹。' : 'Results appear in Activity and are also written into the workspace result folder.')
+                : (isZh ? '还没有执行记录。到点后结果会出现在活动记录里，并自动写入工作区里的 “Lynn-自动任务结果” 文件夹。' : 'No run yet. When the task fires, the result will appear in Activity and in the workspace result folder.')}
+            </div>
+          ) : null}
+        </div>
+      )}
+      <div className={fp.automationJobActions}>
+        <button type="button" className={fp.automationLinkBtn} onClick={() => onRunNow(job.id)}>
+          {isZh ? '立即执行' : 'Run now'}
+        </button>
+        {job.latestActivity?.outputFile ? (
+          <button type="button" className={fp.automationLinkBtn} onClick={openLatestFile}>
+            {isZh ? '打开文件' : 'Open file'}
+          </button>
+        ) : null}
+        {job.latestActivity?.id ? (
+          <button type="button" className={fp.automationLinkBtn} onClick={openLatestResult}>
+            {isZh ? '查看结果' : 'Open result'}
+          </button>
+        ) : null}
+        <button type="button" className={fp.automationLinkBtn} onClick={() => onEdit(job)}>
+          {isZh ? '编辑' : 'Edit'}
+        </button>
+        <button
+          type="button"
+          className={`${fp.automationLinkBtn} ${fp.automationDangerBtn}`}
+          onClick={() => onRemove(job.id)}
+        >
+          {isZh ? '删除' : 'Delete'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/react/components/automation/job-utils.ts
+++ b/desktop/src/react/components/automation/job-utils.ts
@@ -1,0 +1,16 @@
+import type { ModelOption } from './types';
+
+export function resolveJobModelValue(modelRef: string | undefined, options: ModelOption[]): string {
+  const raw = String(modelRef || '').trim();
+  if (!raw) return '';
+  const exact = options.find((option) => option.value === raw);
+  if (exact) return exact.value;
+  const byRawId = options.find((option) => option.rawId === raw);
+  return byRawId?.value || raw;
+}
+
+export function folderLabel(folderPath: string | null): string {
+  if (!folderPath) return '';
+  const parts = folderPath.split(/[\\/]+/).filter(Boolean);
+  return parts[parts.length - 1] || folderPath;
+}

--- a/desktop/src/react/components/automation/types.ts
+++ b/desktop/src/react/components/automation/types.ts
@@ -1,0 +1,36 @@
+export interface CronJob {
+  id: string;
+  enabled: boolean;
+  label?: string;
+  prompt?: string;
+  schedule: string | number;
+  model?: string;
+  workspace?: string;
+  nextRunAt?: string | null;
+  lastRunAt?: string | null;
+  latestRun?: {
+    status?: string;
+    startedAt?: string;
+    finishedAt?: string;
+    error?: string;
+    timestamp?: string;
+  } | null;
+  latestActivity?: {
+    id?: string;
+    summary?: string;
+    status?: string;
+    error?: string | null;
+    startedAt?: number | null;
+    finishedAt?: number | null;
+    sessionFile?: string | null;
+    outputFile?: string | null;
+    workspace?: string;
+  } | null;
+}
+
+export interface ModelOption {
+  value: string;
+  label: string;
+  rawId: string;
+  rawProvider: string;
+}


### PR DESCRIPTION
## Summary
- move automation job card rendering into `desktop/src/react/components/automation/AutomationJobCard.tsx`
- move shared `CronJob` / `ModelOption` contracts into `automation/types.ts`
- move job model/path helpers into `automation/job-utils.ts`
- reduce `AutomationPanel.tsx` from 1107 to 943 lines without changing behavior

## Validation
- `npm run typecheck`
- `npm test -- --reporter=dot desktop/src/react/__tests__/automation-cron-utils.test.ts`
- `npm run release:gate`

No local model artifacts were downloaded.