### PR TITLE
refactor(session): extract runtime tool application

### DIFF
--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -15,14 +15,12 @@ import {
 import { createModuleLogger } from "../lib/debug-log.js";
 import { BrowserManager } from "../lib/browser/browser-manager.js";
 import { t, getLocale } from "../server/i18n.js";
-import { READ_ONLY_BUILTIN_TOOLS } from "./config-coordinator.js";
 import { findModel } from "../shared/model-ref.js";
 import { runReadToolPromptInjectionGuardrail } from "./claw-aegis-guardrails.js";
 import {
   SecurityMode,
   DEFAULT_SECURITY_MODE,
   normalizeSecurityMode,
-  SECURITY_MODE_CONFIG,
 } from "../shared/security-mode.js";
 import {
   buildClientAgentMetadata,
@@ -53,8 +51,9 @@ import {
   sanitizeActiveSessionContextForPrompt,
 } from "./session-prompt-sanitizer.js";
 import {
+  applySessionToolRuntime,
+  buildSessionToolsForEntry,
   filterCustomToolsByTier,
-  getBuiltinToolNames,
   normalizeCustomToolsForModel,
   resolveToolTier,
   shouldSuppressClientToolSchema,
@@ -768,16 +767,13 @@ export class SessionCoordinator {
   }
 
   _buildSessionTools(entry: SessionEntry, modeOverride: string | null = null) {
-    const cwd = entry.session?.sessionManager?.getCwd?.() || this._d.getHomeCwd() || process.cwd();
-    const sessionPath = entry.session?.sessionManager?.getSessionFile?.() || null;
-    const effectiveMode = normalizeSecurityMode(modeOverride || entry.securityMode || DEFAULT_SECURITY_MODE);
-    return this._d.buildTools(cwd, null, {
-      agentDir: this._d.getAgentById(entry.agentId)?.agentDir || this._d.getAgent().agentDir,
-      workspace: cwd,
-      mode: SECURITY_MODE_CONFIG[effectiveMode]?.sandboxMode,
-      getSessionPath: () => sessionPath,
-      // [2026-04-17] MCP 按需激活：sessionEntry.activeMcpServers 由 UI / command 维护
-      activeMcpServers: entry.activeMcpServers || null,
+    return buildSessionToolsForEntry({
+      entry,
+      modeOverride,
+      buildTools: (cwd, extra, options) => this._d.buildTools(cwd, extra, options),
+      getHomeCwd: () => this._d.getHomeCwd(),
+      getAgentById: (agentId) => agentId ? this._d.getAgentById(agentId) : null,
+      getFallbackAgent: () => this._d.getAgent(),
     });
   }
 
@@ -785,46 +781,15 @@ export class SessionCoordinator {
     const entry = this._sessions.get(sessionPath);
     if (!entry) return;
 
-    const effectiveMode = normalizeSecurityMode(modeOverride || entry.securityMode || DEFAULT_SECURITY_MODE);
-    const config = SECURITY_MODE_CONFIG[effectiveMode];
-    const { tools, customTools } = this._buildSessionTools(entry, effectiveMode);
-    const modelRef = entry.session?.model
-      || (entry.modelId ? { id: entry.modelId, provider: entry.modelProvider } : null);
-    const nativeToolsDisabled = isNativeToolCallingDisabled(modelRef);
-    const suppressClientTools = shouldSuppressClientToolSchema(modelRef);
-    if (nativeToolsDisabled) {
-      entry.nativeToolCallingDisabled = true;
-      entry.securityMode = effectiveMode;
-      entry.planMode = effectiveMode === SecurityMode.PLAN;
-      entry.session._customTools = [];
-      entry.session._baseToolsOverride = {};
-      entry.session._buildRuntime({ activeToolNames: [] });
-      log.warn(`[model-tools] runtime tools disabled for ${modelRef?.provider || "?"}/${modelRef?.id || modelRef?.name || "?"}`);
-      return;
-    }
-    if (suppressClientTools) {
-      entry.nativeToolCallingDisabled = false;
-      entry.securityMode = effectiveMode;
-      entry.planMode = effectiveMode === SecurityMode.PLAN;
-      entry.session._customTools = [];
-      entry.session._baseToolsOverride = {};
-      entry.session._buildRuntime({ activeToolNames: [] });
-      log.log(`[model-tools] runtime using Brain V2 internal tool chain for ${modelRef?.provider || "?"}/${modelRef?.id || modelRef?.name || "?"}; client tool schema suppressed`);
-      return;
-    }
-    const baseToolsOverride = Object.fromEntries(tools.map((tool: ToolLike) => [tool.name, tool]));
-    const normalizedCustomTools = normalizeCustomToolsForModel(customTools || [], modelRef);
-    const customNames = normalizedCustomTools.map((tool: ToolLike) => tool.name);
-    const activeToolNames = config.toolsRestricted
-      ? [...READ_ONLY_BUILTIN_TOOLS, ...customNames]
-      : [...getBuiltinToolNames(tools), ...customNames];
-
-    entry.securityMode = effectiveMode;
-    entry.planMode = effectiveMode === SecurityMode.PLAN;
-    entry.nativeToolCallingDisabled = false;
-    entry.session._customTools = normalizedCustomTools;
-    entry.session._baseToolsOverride = baseToolsOverride;
-    entry.session._buildRuntime({ activeToolNames });
+    applySessionToolRuntime({
+      entry,
+      modeOverride,
+      buildTools: (cwd, extra, options) => this._d.buildTools(cwd, extra, options),
+      getHomeCwd: () => this._d.getHomeCwd(),
+      getAgentById: (agentId) => agentId ? this._d.getAgentById(agentId) : null,
+      getFallbackAgent: () => this._d.getAgent(),
+      logger: log,
+    });
   }
 
   /** Set plan mode for the current (focused) session */

--- a/core/session-tool-runtime.ts
+++ b/core/session-tool-runtime.ts
@@ -1,6 +1,13 @@
 import { createModuleLogger } from "../lib/debug-log.js";
+import { READ_ONLY_BUILTIN_TOOLS } from "./config-coordinator.js";
 import { lookupToolTier } from "../shared/known-models.js";
 import { isNativeToolCallingDisabled } from "../shared/model-tool-capabilities.js";
+import {
+  DEFAULT_SECURITY_MODE,
+  normalizeSecurityMode,
+  SECURITY_MODE_CONFIG,
+  SecurityMode,
+} from "../shared/security-mode.js";
 import type { ResolvedModel } from "./types.js";
 
 const log = createModuleLogger("session");
@@ -8,6 +15,43 @@ const log = createModuleLogger("session");
 type AnyRecord = Record<string, any>;
 export type ToolLike = AnyRecord & { name: string };
 export type ModelLike = ResolvedModel | AnyRecord | null;
+
+type SessionEntryLike = AnyRecord & {
+  session?: AnyRecord;
+  agentId?: string;
+  securityMode?: string;
+  planMode?: boolean;
+  modelId?: string | null;
+  modelProvider?: string | null;
+  nativeToolCallingDisabled?: boolean;
+  activeMcpServers?: string[] | null;
+};
+
+type AgentLike = { agentDir?: string } & AnyRecord;
+
+type BuildToolsFn = (
+  cwd: string,
+  extra: unknown,
+  options: AnyRecord,
+) => { tools?: ToolLike[]; customTools?: ToolLike[] };
+
+type LoggerLike = {
+  log?: (message: string) => unknown;
+  warn?: (message: string) => unknown;
+};
+
+export interface BuildSessionToolsOptions {
+  entry: SessionEntryLike;
+  modeOverride?: string | null;
+  buildTools: BuildToolsFn;
+  getHomeCwd: () => string | null | undefined;
+  getAgentById: (agentId?: string) => AgentLike | null | undefined;
+  getFallbackAgent: () => AgentLike;
+}
+
+export interface ApplySessionToolRuntimeOptions extends BuildSessionToolsOptions {
+  logger?: LoggerLike;
+}
 
 const MINIMAL_CUSTOM_TOOLS = new Set([
   "web_search", "web_fetch", "stock_market", "weather", "live_news", "sports_score",
@@ -94,4 +138,90 @@ export function resolveToolTier(model: ModelLike) {
 
 export function getBuiltinToolNames(tools: ToolLike[]) {
   return tools.map((tool: ToolLike) => tool.name);
+}
+
+function modelLabel(model: ModelLike) {
+  return `${model?.provider || "?"}/${model?.id || model?.name || "?"}`;
+}
+
+export function buildSessionToolsForEntry({
+  entry,
+  modeOverride = null,
+  buildTools,
+  getHomeCwd,
+  getAgentById,
+  getFallbackAgent,
+}: BuildSessionToolsOptions) {
+  const cwd = entry.session?.sessionManager?.getCwd?.() || getHomeCwd() || process.cwd();
+  const sessionPath = entry.session?.sessionManager?.getSessionFile?.() || null;
+  const effectiveMode = normalizeSecurityMode(modeOverride || entry.securityMode || DEFAULT_SECURITY_MODE);
+  return buildTools(cwd, null, {
+    agentDir: getAgentById(entry.agentId)?.agentDir || getFallbackAgent().agentDir,
+    workspace: cwd,
+    mode: SECURITY_MODE_CONFIG[effectiveMode]?.sandboxMode,
+    getSessionPath: () => sessionPath,
+    // [2026-04-17] MCP 按需激活：sessionEntry.activeMcpServers 由 UI / command 维护
+    activeMcpServers: entry.activeMcpServers || null,
+  });
+}
+
+export function applySessionToolRuntime({
+  entry,
+  modeOverride = null,
+  buildTools,
+  getHomeCwd,
+  getAgentById,
+  getFallbackAgent,
+  logger = log,
+}: ApplySessionToolRuntimeOptions) {
+  const session = entry.session;
+  if (!session) return;
+
+  const effectiveMode = normalizeSecurityMode(modeOverride || entry.securityMode || DEFAULT_SECURITY_MODE);
+  const config = SECURITY_MODE_CONFIG[effectiveMode];
+  const { tools = [], customTools = [] } = buildSessionToolsForEntry({
+    entry,
+    modeOverride: effectiveMode,
+    buildTools,
+    getHomeCwd,
+    getAgentById,
+    getFallbackAgent,
+  });
+  const modelRef = session.model
+    || (entry.modelId ? { id: entry.modelId, provider: entry.modelProvider } : null);
+  const nativeToolsDisabled = isNativeToolCallingDisabled(modelRef);
+  const suppressClientTools = shouldSuppressClientToolSchema(modelRef);
+
+  entry.securityMode = effectiveMode;
+  entry.planMode = effectiveMode === SecurityMode.PLAN;
+
+  if (nativeToolsDisabled) {
+    entry.nativeToolCallingDisabled = true;
+    session._customTools = [];
+    session._baseToolsOverride = {};
+    session._buildRuntime({ activeToolNames: [] });
+    logger.warn?.(`[model-tools] runtime tools disabled for ${modelLabel(modelRef)}`);
+    return;
+  }
+
+  if (suppressClientTools) {
+    entry.nativeToolCallingDisabled = false;
+    session._customTools = [];
+    session._baseToolsOverride = {};
+    session._buildRuntime({ activeToolNames: [] });
+    logger.log?.(`[model-tools] runtime using Brain V2 internal tool chain for ${modelLabel(modelRef)}; client tool schema suppressed`);
+    return;
+  }
+
+  const baseToolsOverride = Object.fromEntries(tools.map((tool: ToolLike) => [tool.name, tool]));
+  const normalizedCustomTools = normalizeCustomToolsForModel(customTools || [], modelRef);
+  const customNames = normalizedCustomTools.map((tool: ToolLike) => tool.name);
+  const activeToolNames = config.toolsRestricted
+    ? [...READ_ONLY_BUILTIN_TOOLS, ...customNames]
+    : [...getBuiltinToolNames(tools), ...customNames];
+
+  entry.nativeToolCallingDisabled = false;
+  session._customTools = normalizedCustomTools;
+  session._baseToolsOverride = baseToolsOverride;
+  session._buildRuntime({ activeToolNames });
 }

--- a/tests/session-tool-runtime.test.js
+++ b/tests/session-tool-runtime.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applySessionToolRuntime,
+  buildSessionToolsForEntry,
+} from "../core/session-tool-runtime.js";
+
+function makeEntry({ mode = "authorized", model = { id: "qwen", provider: "local" } } = {}) {
+  return {
+    agentId: "lynn",
+    securityMode: mode,
+    activeMcpServers: ["memory"],
+    session: {
+      model,
+      sessionManager: {
+        getCwd: () => "/tmp/workspace",
+        getSessionFile: () => "/tmp/session.jsonl",
+      },
+      _buildRuntime: vi.fn(),
+    },
+  };
+}
+
+function makeDeps(buildTools = vi.fn(() => ({
+  tools: [{ name: "read" }, { name: "grep" }, { name: "bash" }],
+  customTools: [{ name: "notify" }],
+}))) {
+  return {
+    buildTools,
+    getHomeCwd: () => "/tmp/home",
+    getAgentById: vi.fn(() => ({ agentDir: "/tmp/agent" })),
+    getFallbackAgent: () => ({ agentDir: "/tmp/fallback-agent" }),
+  };
+}
+
+describe("session tool runtime helpers", () => {
+  it("builds tool options from the session entry and security mode", () => {
+    const entry = makeEntry({ mode: "plan" });
+    const deps = makeDeps();
+
+    buildSessionToolsForEntry({ entry, ...deps });
+
+    expect(deps.buildTools).toHaveBeenCalledWith("/tmp/workspace", null, expect.objectContaining({
+      agentDir: "/tmp/agent",
+      workspace: "/tmp/workspace",
+      mode: "standard",
+      activeMcpServers: ["memory"],
+    }));
+    const options = deps.buildTools.mock.calls[0][2];
+    expect(options.getSessionPath()).toBe("/tmp/session.jsonl");
+  });
+
+  it("applies full runtime tools in authorized mode", () => {
+    const entry = makeEntry();
+    const deps = makeDeps();
+
+    applySessionToolRuntime({ entry, ...deps });
+
+    expect(entry.planMode).toBe(false);
+    expect(entry.nativeToolCallingDisabled).toBe(false);
+    expect(entry.session._customTools).toEqual([{ name: "notify" }]);
+    expect(entry.session._baseToolsOverride).toMatchObject({
+      read: { name: "read" },
+      grep: { name: "grep" },
+      bash: { name: "bash" },
+    });
+    expect(entry.session._buildRuntime).toHaveBeenCalledWith({
+      activeToolNames: ["read", "grep", "bash", "notify"],
+    });
+  });
+
+  it("limits built-in tools in plan mode while keeping custom tools", () => {
+    const entry = makeEntry({ mode: "plan" });
+    const deps = makeDeps();
+
+    applySessionToolRuntime({ entry, ...deps });
+
+    expect(entry.planMode).toBe(true);
+    expect(entry.session._buildRuntime).toHaveBeenCalledWith({
+      activeToolNames: ["read", "grep", "find", "ls", "notify"],
+    });
+  });
+
+  it("disables runtime tools for models with broken native tool calls", () => {
+    const entry = makeEntry({
+      model: { id: "lynn-nvfp4-prism", provider: "local" },
+    });
+    const deps = makeDeps();
+    const logger = { warn: vi.fn(), log: vi.fn() };
+
+    applySessionToolRuntime({ entry, ...deps, logger });
+
+    expect(entry.nativeToolCallingDisabled).toBe(true);
+    expect(entry.session._customTools).toEqual([]);
+    expect(entry.session._baseToolsOverride).toEqual({});
+    expect(entry.session._buildRuntime).toHaveBeenCalledWith({ activeToolNames: [] });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("runtime tools disabled"));
+  });
+});


### PR DESCRIPTION
## Summary
- move session runtime tool rebuild logic into session-tool-runtime helpers
- keep SessionCoordinator as a thin orchestration wrapper
- add direct tests for authorized, plan, and disabled-tool-call runtime paths

## Verification
- npm run typecheck
- npm run typecheck:runtime
- npm test -- --reporter=dot tests/session-tool-runtime.test.js tests/session-coordinator.test.js tests/session-list-cache.test.js tests/model-no-fallback.test.js tests/session-model-isolation.test.js tests/vision-arg-regression.test.js
- npm run release:gate