### PR TITLE
refactor(session): extract cache lifecycle helpers

### DIFF
--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -65,6 +65,14 @@ import {
   refreshMissingSessionIndexes,
 } from "./session-list-cache.js";
 import {
+  abortAllStreamingSessions,
+  abortCachedSessionByPath,
+  closeAllCachedSessions,
+  closeCachedSession,
+  getCachedSessionByPath,
+  isCachedSessionStreaming,
+} from "./session-lifecycle.js";
+import {
   formatRelaySummaryContext,
   resolveSessionRelayConfig,
   runSessionRelay,
@@ -901,47 +909,29 @@ export class SessionCoordinator {
 
   /** 中断所有正在 streaming 的 session */
   async abortAllStreaming() {
-    const tasks = [];
-    for (const [sp, entry] of this._sessions) {
-      if (entry.session.isStreaming) {
-        tasks.push(entry.session.abort().catch(() => {}));
-      }
-    }
-    await Promise.all(tasks);
-    return tasks.length;
+    return abortAllStreamingSessions(this._sessions);
   }
 
   // ── Session 关闭 ──
 
   async closeSession(sessionPath: string) {
-    const entry = this._sessions.get(sessionPath);
-    if (entry) {
-      const agent = this._d.getAgentById(entry.agentId) || this._d.getAgent();
-      notifyMemorySessionEnd(agent, sessionPath, "close session");
-      if (entry.session.isStreaming) {
-        try { await entry.session.abort(); } catch {}
-      }
-      entry.unsub();
-      this._sessions.delete(sessionPath);
-
-      // 清理该 session 的 pending confirmation
-      this._d.getConfirmStore?.()?.abortBySession(sessionPath);
-    }
-    if (sessionPath === this.currentSessionPath) {
-      this._session = null;
-    }
+    return closeCachedSession({
+      sessions: this._sessions,
+      sessionPath,
+      currentSessionPath: this.currentSessionPath,
+      setCurrentSession: (session) => { this._session = session; },
+      getAgentById: (agentId) => this._d.getAgentById(agentId),
+      getFallbackAgent: () => this._d.getAgent(),
+      notifySessionEnd: notifyMemorySessionEnd,
+      getConfirmStore: () => this._d.getConfirmStore?.(),
+    });
   }
 
   async closeAllSessions() {
-    // abort all streaming sessions + unsub（记忆收尾由 disposeAll 带超时处理）
-    for (const [, entry] of this._sessions) {
-      if (entry.session.isStreaming) {
-        try { await entry.session.abort(); } catch {}
-      }
-      entry.unsub();
-    }
-    this._sessions.clear();
-    this._session = null;
+    return closeAllCachedSessions({
+      sessions: this._sessions,
+      setCurrentSession: (session) => { this._session = session; },
+    });
   }
 
   async cleanupSession() {
@@ -952,18 +942,15 @@ export class SessionCoordinator {
   // ── Session 查询 ──
 
   getSessionByPath(sessionPath: string) {
-    return this._sessions.get(sessionPath)?.session ?? null;
+    return getCachedSessionByPath(this._sessions, sessionPath);
   }
 
   isSessionStreaming(sessionPath: string) {
-    return !!this.getSessionByPath(sessionPath)?.isStreaming;
+    return isCachedSessionStreaming(this._sessions, sessionPath);
   }
 
   async abortSessionByPath(sessionPath: string) {
-    const session = this.getSessionByPath(sessionPath);
-    if (!session?.isStreaming) return false;
-    await session.abort();
-    return true;
+    return abortCachedSessionByPath(this._sessions, sessionPath);
   }
 
   async listSessions() {

--- a/core/session-lifecycle.ts
+++ b/core/session-lifecycle.ts
@@ -1,0 +1,96 @@
+type AnyRecord = Record<string, any>;
+
+type SessionLike = AnyRecord & {
+  isStreaming?: boolean;
+  abort?: () => Promise<unknown> | unknown;
+};
+
+type SessionEntryLike = AnyRecord & {
+  session?: SessionLike;
+  agentId?: string;
+  unsub?: () => void;
+};
+
+type AgentLike = AnyRecord;
+
+type ConfirmStoreLike = {
+  abortBySession?: (sessionPath: string) => unknown;
+};
+
+export function getCachedSessionByPath(
+  sessions: Map<string, SessionEntryLike>,
+  sessionPath: string,
+) {
+  return sessions.get(sessionPath)?.session ?? null;
+}
+
+export function isCachedSessionStreaming(
+  sessions: Map<string, SessionEntryLike>,
+  sessionPath: string,
+) {
+  return !!getCachedSessionByPath(sessions, sessionPath)?.isStreaming;
+}
+
+export async function abortCachedSessionByPath(
+  sessions: Map<string, SessionEntryLike>,
+  sessionPath: string,
+) {
+  const session = getCachedSessionByPath(sessions, sessionPath);
+  if (!session?.isStreaming) return false;
+  await session.abort?.();
+  return true;
+}
+
+export async function abortAllStreamingSessions(
+  sessions: Map<string, SessionEntryLike>,
+) {
+  const tasks: Promise<unknown>[] = [];
+  for (const [, entry] of sessions) {
+    if (entry.session?.isStreaming) {
+      tasks.push(Promise.resolve(entry.session.abort?.()).catch(() => {}));
+    }
+  }
+  await Promise.all(tasks);
+  return tasks.length;
+}
+
+export async function closeCachedSession(opts: {
+  sessions: Map<string, SessionEntryLike>;
+  sessionPath: string;
+  currentSessionPath?: string | null;
+  setCurrentSession: (session: SessionLike | null) => void;
+  getAgentById: (agentId: string) => AgentLike | null | undefined;
+  getFallbackAgent: () => AgentLike | null | undefined;
+  notifySessionEnd: (agent: AgentLike | null | undefined, sessionPath: string, context: string) => unknown;
+  getConfirmStore?: () => ConfirmStoreLike | null | undefined;
+}) {
+  const entry = opts.sessions.get(opts.sessionPath);
+  if (entry) {
+    const agent = opts.getAgentById(String(entry.agentId || "")) || opts.getFallbackAgent();
+    opts.notifySessionEnd(agent, opts.sessionPath, "close session");
+    if (entry.session?.isStreaming) {
+      try { await entry.session.abort?.(); } catch {}
+    }
+    entry.unsub?.();
+    opts.sessions.delete(opts.sessionPath);
+    opts.getConfirmStore?.()?.abortBySession?.(opts.sessionPath);
+  }
+
+  if (opts.sessionPath === opts.currentSessionPath) {
+    opts.setCurrentSession(null);
+  }
+}
+
+export async function closeAllCachedSessions(opts: {
+  sessions: Map<string, SessionEntryLike>;
+  setCurrentSession: (session: SessionLike | null) => void;
+}) {
+  for (const [, entry] of opts.sessions) {
+    if (entry.session?.isStreaming) {
+      try { await entry.session.abort?.(); } catch {}
+    }
+    entry.unsub?.();
+  }
+  opts.sessions.clear();
+  opts.setCurrentSession(null);
+}

--- a/tests/session-lifecycle.test.js
+++ b/tests/session-lifecycle.test.js
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  abortAllStreamingSessions,
+  abortCachedSessionByPath,
+  closeAllCachedSessions,
+  closeCachedSession,
+  getCachedSessionByPath,
+  isCachedSessionStreaming,
+} from "../core/session-lifecycle.js";
+
+describe("session lifecycle helpers", () => {
+  it("aborts only streaming sessions and ignores abort failures", async () => {
+    const abortOk = vi.fn(async () => {});
+    const abortFail = vi.fn(async () => { throw new Error("closed"); });
+    const abortIdle = vi.fn(async () => {});
+    const sessions = new Map([
+      ["a", { session: { isStreaming: true, abort: abortOk } }],
+      ["b", { session: { isStreaming: true, abort: abortFail } }],
+      ["c", { session: { isStreaming: false, abort: abortIdle } }],
+    ]);
+
+    await expect(abortAllStreamingSessions(sessions)).resolves.toBe(2);
+    expect(abortOk).toHaveBeenCalledTimes(1);
+    expect(abortFail).toHaveBeenCalledTimes(1);
+    expect(abortIdle).not.toHaveBeenCalled();
+  });
+
+  it("closes a cached session with memory notification, unsubscribe, and confirm cleanup", async () => {
+    const abort = vi.fn(async () => {});
+    const unsub = vi.fn();
+    const notifySessionEnd = vi.fn();
+    const abortBySession = vi.fn();
+    const setCurrentSession = vi.fn();
+    const sessions = new Map([
+      ["current", { agentId: "agent-a", session: { isStreaming: true, abort }, unsub }],
+    ]);
+
+    await closeCachedSession({
+      sessions,
+      sessionPath: "current",
+      currentSessionPath: "current",
+      setCurrentSession,
+      getAgentById: (agentId) => ({ id: agentId }),
+      getFallbackAgent: () => ({ id: "fallback" }),
+      notifySessionEnd,
+      getConfirmStore: () => ({ abortBySession }),
+    });
+
+    expect(notifySessionEnd).toHaveBeenCalledWith({ id: "agent-a" }, "current", "close session");
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(unsub).toHaveBeenCalledTimes(1);
+    expect(abortBySession).toHaveBeenCalledWith("current");
+    expect(sessions.has("current")).toBe(false);
+    expect(setCurrentSession).toHaveBeenCalledWith(null);
+  });
+
+  it("closes all cached sessions and clears the active session reference", async () => {
+    const abort = vi.fn(async () => {});
+    const unsubA = vi.fn();
+    const unsubB = vi.fn();
+    const setCurrentSession = vi.fn();
+    const sessions = new Map([
+      ["a", { session: { isStreaming: true, abort }, unsub: unsubA }],
+      ["b", { session: { isStreaming: false }, unsub: unsubB }],
+    ]);
+
+    await closeAllCachedSessions({ sessions, setCurrentSession });
+
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(unsubA).toHaveBeenCalledTimes(1);
+    expect(unsubB).toHaveBeenCalledTimes(1);
+    expect(sessions.size).toBe(0);
+    expect(setCurrentSession).toHaveBeenCalledWith(null);
+  });
+
+  it("reads and aborts cached sessions by path", async () => {
+    const abort = vi.fn(async () => {});
+    const session = { isStreaming: true, abort };
+    const sessions = new Map([["s", { session }]]);
+
+    expect(getCachedSessionByPath(sessions, "s")).toBe(session);
+    expect(isCachedSessionStreaming(sessions, "s")).toBe(true);
+    await expect(abortCachedSessionByPath(sessions, "s")).resolves.toBe(true);
+    expect(abort).toHaveBeenCalledTimes(1);
+    await expect(abortCachedSessionByPath(sessions, "missing")).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- move cached-session abort/close/query helpers out of SessionCoordinator
- keep coordinator as a thin lifecycle wrapper
- add direct lifecycle coverage for streaming abort, close cleanup, close-all, and path queries

## Verification
- npm run typecheck
- npm run typecheck:runtime
- npm test -- --reporter=dot tests/session-lifecycle.test.js tests/session-coordinator.test.js tests/session-list-cache.test.js tests/session-relay.test.js
- npm run release:gate