### PR TITLE
refactor(session): extract turn context helpers

### DIFF
--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -30,19 +30,13 @@ import {
 import { resolveCompactionSettings } from "./compaction-settings.js";
 import { getUserFacingRoleModelLabel, resolveRoleDefaultModel } from "../shared/assistant-role-models.js";
 import {
-  classifyRouteIntent,
   ROUTE_INTENTS,
 } from "../shared/task-route-intent.js";
 import {
   isNativeToolCallingDisabled,
 } from "../shared/model-tool-capabilities.js";
 import {
-  buildAtInjectionPromptHint,
-  buildRouteAndScenarioHint,
-  buildScenarioHintContext,
-  buildSkillHintContext,
   getSteerPrefix,
-  shouldAttachSkillHint,
   toSessionPromptOptions,
 } from "./session-context-hints.js";
 import {
@@ -93,6 +87,10 @@ import {
   resolveIsolatedExecutionModel,
 } from "./session-isolated-runtime.js";
 import { createSessionResourceLoader } from "./session-resource-loader.js";
+import {
+  clearSessionTurnContext,
+  prepareSessionTurnContext,
+} from "./session-turn-context.js";
 import type { ResolvedModel } from "./types.js";
 
 export { PATROL_TOOLS_DEFAULT } from "./session-isolated-runtime.js";
@@ -514,34 +512,16 @@ export class SessionCoordinator {
     if (sp) {
       const entry = this._sessions.get(sp);
       if (entry) {
-        try {
-          const cwd = this._session?.sessionManager?.getCwd?.() || "";
-          const recallCtx = await agent.recallForMessage(text, cwd);
-          entry._lastRecallContext = recallCtx || "";
-        } catch {
-          entry._lastRecallContext = "";
-        }
-        entry._routeIntentValue = classifyRouteIntent(text, { imagesCount: opts?.images?.length || 0 });
-        entry._routeIntentHintContext = buildRouteAndScenarioHint(
+        await prepareSessionTurnContext({
+          entry,
           text,
-          entry._routeIntentValue,
-          { locale: getLocale(), imagesCount: opts?.images?.length || 0 },
-        );
-        entry._scenarioContractHintContext = buildScenarioHintContext(
-          text,
-          { locale: getLocale(), imagesCount: opts?.images?.length || 0 },
-        );
-        try {
-          const suggestions = this._d.getSkills?.()?.suggestSkillsForText?.(agent, text, 3) || [];
-          entry._lastSkillHintContext = shouldAttachSkillHint(entry._routeIntentValue)
-            ? buildSkillHintContext(suggestions)
-            : "";
-        } catch {
-          entry._lastSkillHintContext = "";
-        }
-        entry._atInjectionHintContext = buildAtInjectionPromptHint(text);
-        entry._turnInstructionHintContext = String(opts?.turnInstruction || "").trim();
-        await this._maybeRouteAroundBrokenToolModel(entry, entry._routeIntentValue, agent, sp);
+          agent,
+          imagesCount: opts?.images?.length || 0,
+          turnInstruction: opts?.turnInstruction,
+          locale: getLocale(),
+          getSkills: () => this._d.getSkills?.(),
+          routeAroundBrokenToolModel: (routeIntent) => this._maybeRouteAroundBrokenToolModel(entry, routeIntent, agent, sp),
+        });
       }
     }
 
@@ -584,15 +564,7 @@ export class SessionCoordinator {
     } finally {
       if (sp) {
         const entry = this._sessions.get(sp);
-        if (entry) {
-          entry._lastRecallContext = "";
-          entry._lastSkillHintContext = "";
-          entry._atInjectionHintContext = "";
-          entry._turnInstructionHintContext = "";
-          entry._routeIntentHintContext = "";
-          entry._scenarioContractHintContext = "";
-          entry._routeIntentValue = ROUTE_INTENTS.CHAT;
-        }
+        if (entry) clearSessionTurnContext(entry);
       }
     }
   }
@@ -631,34 +603,16 @@ export class SessionCoordinator {
 
     // Phase 1: 主动记忆召回
     const agent = this._d.getAgentById(entry.agentId) || this._d.getAgent();
-    try {
-      const cwd = entry.session?.sessionManager?.getCwd?.() || "";
-      const recallCtx = await agent.recallForMessage(text, cwd);
-      entry._lastRecallContext = recallCtx || "";
-    } catch {
-      entry._lastRecallContext = "";
-    }
-    entry._routeIntentValue = classifyRouteIntent(text, { imagesCount: opts?.images?.length || 0 });
-    entry._routeIntentHintContext = buildRouteAndScenarioHint(
+    await prepareSessionTurnContext({
+      entry,
       text,
-      entry._routeIntentValue,
-      { locale: getLocale(), imagesCount: opts?.images?.length || 0 },
-    );
-    entry._scenarioContractHintContext = buildScenarioHintContext(
-      text,
-      { locale: getLocale(), imagesCount: opts?.images?.length || 0 },
-    );
-    try {
-      const suggestions = this._d.getSkills?.()?.suggestSkillsForText?.(agent, text, 3) || [];
-      entry._lastSkillHintContext = shouldAttachSkillHint(entry._routeIntentValue)
-        ? buildSkillHintContext(suggestions)
-        : "";
-    } catch {
-      entry._lastSkillHintContext = "";
-    }
-    entry._atInjectionHintContext = buildAtInjectionPromptHint(text);
-    entry._turnInstructionHintContext = String(opts?.turnInstruction || "").trim();
-    await this._maybeRouteAroundBrokenToolModel(entry, entry._routeIntentValue, agent, sessionPath);
+      agent,
+      imagesCount: opts?.images?.length || 0,
+      turnInstruction: opts?.turnInstruction,
+      locale: getLocale(),
+      getSkills: () => this._d.getSkills?.(),
+      routeAroundBrokenToolModel: (routeIntent) => this._maybeRouteAroundBrokenToolModel(entry, routeIntent, agent, sessionPath),
+    });
 
     if (sessionPath === this.currentSessionPath) this._sessionStarted = true;
     // 非 vision 模型：静默剥离图片（与 bridge-session-manager 保持一致）
@@ -690,13 +644,7 @@ export class SessionCoordinator {
       }
       agent?._memoryTicker?.notifyTurn(sessionPath);
     } finally {
-      entry._lastRecallContext = "";
-      entry._lastSkillHintContext = "";
-      entry._atInjectionHintContext = "";
-      entry._turnInstructionHintContext = "";
-      entry._routeIntentHintContext = "";
-      entry._scenarioContractHintContext = "";
-      entry._routeIntentValue = ROUTE_INTENTS.CHAT;
+      clearSessionTurnContext(entry);
     }
   }
 

--- a/core/session-turn-context.ts
+++ b/core/session-turn-context.ts
@@ -1,0 +1,83 @@
+import { getLocale } from "../server/i18n.js";
+import {
+  classifyRouteIntent,
+  ROUTE_INTENTS,
+} from "../shared/task-route-intent.js";
+import {
+  buildAtInjectionPromptHint,
+  buildRouteAndScenarioHint,
+  buildScenarioHintContext,
+  buildSkillHintContext,
+  shouldAttachSkillHint,
+} from "./session-context-hints.js";
+
+type AnyRecord = Record<string, any>;
+
+type AgentLike = AnyRecord & {
+  recallForMessage?: (text: string, cwd: string) => Promise<string | null | undefined> | string | null | undefined;
+};
+
+type SessionEntryLike = AnyRecord & {
+  session?: AnyRecord;
+};
+
+type SkillsLike = {
+  suggestSkillsForText?: (agent: AgentLike, text: string, limit: number) => AnyRecord[];
+};
+
+export async function prepareSessionTurnContext(opts: {
+  entry: SessionEntryLike;
+  text: string;
+  agent: AgentLike;
+  imagesCount?: number;
+  turnInstruction?: unknown;
+  locale?: string;
+  getSkills?: () => SkillsLike | null | undefined;
+  routeAroundBrokenToolModel?: (routeIntent: string) => Promise<unknown> | unknown;
+}) {
+  const imagesCount = Number(opts.imagesCount || 0);
+  const locale = opts.locale || getLocale();
+
+  try {
+    const cwd = opts.entry.session?.sessionManager?.getCwd?.() || "";
+    const recallCtx = await opts.agent.recallForMessage?.(opts.text, cwd);
+    opts.entry._lastRecallContext = recallCtx || "";
+  } catch {
+    opts.entry._lastRecallContext = "";
+  }
+
+  const routeIntent = classifyRouteIntent(opts.text, { imagesCount });
+  opts.entry._routeIntentValue = routeIntent;
+  opts.entry._routeIntentHintContext = buildRouteAndScenarioHint(
+    opts.text,
+    routeIntent,
+    { locale, imagesCount },
+  );
+  opts.entry._scenarioContractHintContext = buildScenarioHintContext(
+    opts.text,
+    { locale, imagesCount },
+  );
+
+  try {
+    const suggestions = opts.getSkills?.()?.suggestSkillsForText?.(opts.agent, opts.text, 3) || [];
+    opts.entry._lastSkillHintContext = shouldAttachSkillHint(routeIntent)
+      ? buildSkillHintContext(suggestions)
+      : "";
+  } catch {
+    opts.entry._lastSkillHintContext = "";
+  }
+
+  opts.entry._atInjectionHintContext = buildAtInjectionPromptHint(opts.text);
+  opts.entry._turnInstructionHintContext = String(opts.turnInstruction || "").trim();
+  await opts.routeAroundBrokenToolModel?.(routeIntent);
+}
+
+export function clearSessionTurnContext(entry: SessionEntryLike) {
+  entry._lastRecallContext = "";
+  entry._lastSkillHintContext = "";
+  entry._atInjectionHintContext = "";
+  entry._turnInstructionHintContext = "";
+  entry._routeIntentHintContext = "";
+  entry._scenarioContractHintContext = "";
+  entry._routeIntentValue = ROUTE_INTENTS.CHAT;
+}

--- a/tests/session-turn-context.test.js
+++ b/tests/session-turn-context.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  clearSessionTurnContext,
+  prepareSessionTurnContext,
+} from "../core/session-turn-context.js";
+
+describe("session turn context helpers", () => {
+  it("prepares recall, route, skill, at-file, and turn instruction context", async () => {
+    const entry = {
+      session: {
+        sessionManager: { getCwd: () => "/tmp/workspace" },
+      },
+    };
+    const agent = {
+      recallForMessage: vi.fn(async () => "remembered facts"),
+    };
+    const routeAroundBrokenToolModel = vi.fn();
+
+    await prepareSessionTurnContext({
+      entry,
+      text: "请修改 app.ts 修复这个 bug",
+      agent,
+      imagesCount: 0,
+      turnInstruction: "reply briefly",
+      locale: "zh-CN",
+      getSkills: () => ({
+        suggestSkillsForText: () => [{ name: "ts-fix", description: "TypeScript fix" }],
+      }),
+      routeAroundBrokenToolModel,
+    });
+
+    expect(agent.recallForMessage).toHaveBeenCalledWith("请修改 app.ts 修复这个 bug", "/tmp/workspace");
+    expect(entry._lastRecallContext).toBe("remembered facts");
+    expect(entry._routeIntentValue).toBe("coding");
+    expect(typeof entry._routeIntentHintContext).toBe("string");
+    expect(typeof entry._scenarioContractHintContext).toBe("string");
+    expect(entry._lastSkillHintContext).toContain("ts-fix");
+    expect(entry._atInjectionHintContext).toContain("@app.ts");
+    expect(entry._turnInstructionHintContext).toBe("reply briefly");
+    expect(routeAroundBrokenToolModel).toHaveBeenCalledWith("coding");
+  });
+
+  it("clears transient context after a turn", () => {
+    const entry = {
+      _lastRecallContext: "memory",
+      _lastSkillHintContext: "skill",
+      _atInjectionHintContext: "at",
+      _turnInstructionHintContext: "instruction",
+      _routeIntentHintContext: "route",
+      _scenarioContractHintContext: "scenario",
+      _routeIntentValue: "coding",
+    };
+
+    clearSessionTurnContext(entry);
+
+    expect(entry).toMatchObject({
+      _lastRecallContext: "",
+      _lastSkillHintContext: "",
+      _atInjectionHintContext: "",
+      _turnInstructionHintContext: "",
+      _routeIntentHintContext: "",
+      _scenarioContractHintContext: "",
+      _routeIntentValue: "chat",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- move duplicated prompt/promptSession turn-context preparation into session-turn-context
- centralize transient turn-context cleanup
- add direct coverage for recall, route intent, skill hints, @ file guidance, and cleanup reset

## Verification
- npm run typecheck
- npm run typecheck:runtime
- npm test -- --reporter=dot tests/session-turn-context.test.js tests/session-coordinator.test.js tests/session-model-isolation.test.js tests/vision-arg-regression.test.js
- npm run release:gate