### PR TITLE
refactor(session): extract switch meta restore

### DIFF
--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -6,7 +6,6 @@
  * 不持有 engine 引用，通过构造器注入依赖。
  */
 import fs from "fs";
-import path from "path";
 import {
   createAgentSession,
   SessionManager,
@@ -91,6 +90,7 @@ import {
   clearSessionTurnContext,
   prepareSessionTurnContext,
 } from "./session-turn-context.js";
+import { readSessionSwitchMeta } from "./session-switch-meta.js";
 import type { ResolvedModel } from "./types.js";
 
 export { PATROL_TOOLS_DEFAULT } from "./session-isolated-runtime.js";
@@ -435,25 +435,11 @@ export class SessionCoordinator {
     }
 
     // 从 session-meta.json 恢复记忆开关 & 模型
-    let memoryEnabled = true;
-    let savedModelRef: { id: string; provider?: string } | null = null;  // {id, provider} or null
-    try {
-      const metaPath = path.join(this._d.getAgent().sessionDir, "session-meta.json");
-      const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
-      const sessKey = path.basename(sessionPath);
-      const metaEntry = meta[sessKey];
-      if (metaEntry?.memoryEnabled === false) memoryEnabled = false;
-      // 读取新格式 model:{id,provider} 或旧格式 modelId
-      if (metaEntry?.model && typeof metaEntry.model === "object") {
-        savedModelRef = metaEntry.model;
-      } else if (metaEntry?.modelId) {
-        savedModelRef = { id: metaEntry.modelId, provider: "" };
-      }
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        log.warn(`session-meta.json 读取失败: ${errMessage(err)}`);
-      }
-    }
+    const { memoryEnabled, savedModelRef } = readSessionSwitchMeta({
+      sessionPath,
+      sessionDir: this._d.getAgent().sessionDir,
+      onReadError: (err) => log.warn(`session-meta.json 读取失败: ${errMessage(err)}`),
+    });
 
     // 如果已在 map 中，切指针
     const existing = this._sessions.get(sessionPath);

--- a/core/session-switch-meta.ts
+++ b/core/session-switch-meta.ts
@@ -1,0 +1,33 @@
+import fs from "fs";
+import path from "path";
+
+type ModelRef = { id: string; provider?: string };
+
+export function readSessionSwitchMeta(opts: {
+  sessionPath: string;
+  sessionDir: string;
+  onReadError?: (err: unknown) => void;
+}) {
+  let memoryEnabled = true;
+  let savedModelRef: ModelRef | null = null;
+
+  try {
+    const metaPath = path.join(opts.sessionDir, "session-meta.json");
+    const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+    const sessKey = path.basename(opts.sessionPath);
+    const metaEntry = meta[sessKey];
+    if (metaEntry?.memoryEnabled === false) memoryEnabled = false;
+    // 读取新格式 model:{id,provider} 或旧格式 modelId
+    if (metaEntry?.model && typeof metaEntry.model === "object") {
+      savedModelRef = metaEntry.model;
+    } else if (metaEntry?.modelId) {
+      savedModelRef = { id: metaEntry.modelId, provider: "" };
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      opts.onReadError?.(err);
+    }
+  }
+
+  return { memoryEnabled, savedModelRef };
+}

--- a/tests/session-switch-meta.test.js
+++ b/tests/session-switch-meta.test.js
@@ -1,0 +1,70 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readSessionSwitchMeta } from "../core/session-switch-meta.js";
+
+describe("session switch meta helper", () => {
+  const dirs = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function tempDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lynn-session-switch-meta-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  it("reads memory state and new model ref format", () => {
+    const dir = tempDir();
+    const sessionPath = path.join(dir, "s.jsonl");
+    fs.writeFileSync(path.join(dir, "session-meta.json"), JSON.stringify({
+      "s.jsonl": {
+        memoryEnabled: false,
+        model: { id: "qwen", provider: "local" },
+      },
+    }));
+
+    expect(readSessionSwitchMeta({ sessionPath, sessionDir: dir })).toEqual({
+      memoryEnabled: false,
+      savedModelRef: { id: "qwen", provider: "local" },
+    });
+  });
+
+  it("reads legacy modelId format", () => {
+    const dir = tempDir();
+    const sessionPath = path.join(dir, "old.jsonl");
+    fs.writeFileSync(path.join(dir, "session-meta.json"), JSON.stringify({
+      "old.jsonl": { modelId: "legacy-model" },
+    }));
+
+    expect(readSessionSwitchMeta({ sessionPath, sessionDir: dir })).toEqual({
+      memoryEnabled: true,
+      savedModelRef: { id: "legacy-model", provider: "" },
+    });
+  });
+
+  it("ignores missing meta file and reports malformed meta", () => {
+    const dir = tempDir();
+    const onReadError = vi.fn();
+
+    expect(readSessionSwitchMeta({
+      sessionPath: path.join(dir, "missing.jsonl"),
+      sessionDir: dir,
+      onReadError,
+    })).toEqual({ memoryEnabled: true, savedModelRef: null });
+    expect(onReadError).not.toHaveBeenCalled();
+
+    fs.writeFileSync(path.join(dir, "session-meta.json"), "{nope");
+    expect(readSessionSwitchMeta({
+      sessionPath: path.join(dir, "bad.jsonl"),
+      sessionDir: dir,
+      onReadError,
+    })).toEqual({ memoryEnabled: true, savedModelRef: null });
+    expect(onReadError).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract session switch metadata restore into `core/session-switch-meta.ts`
- Keep `switchSession` focused on orchestration instead of parsing `session-meta.json` inline
- Add coverage for new model format, legacy `modelId`, missing meta, and malformed meta logging

## Validation
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npm test -- --reporter=dot tests/session-switch-meta.test.js tests/session-coordinator.test.js tests/model-no-fallback.test.js`
- `npm run release:gate`
