### PR TITLE
refactor(session): extract switch runtime helpers

### DIFF
--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -91,6 +91,11 @@ import {
   prepareSessionTurnContext,
 } from "./session-turn-context.js";
 import { readSessionSwitchMeta } from "./session-switch-meta.js";
+import {
+  notifyActiveSessionEnd,
+  prepareCachedSessionSwitch,
+  resolveColdStartSwitchModel,
+} from "./session-switch-runtime.js";
 import type { ResolvedModel } from "./types.js";
 
 export { PATROL_TOOLS_DEFAULT } from "./session-isolated-runtime.js";
@@ -444,39 +449,35 @@ export class SessionCoordinator {
     // 如果已在 map 中，切指针
     const existing = this._sessions.get(sessionPath);
     if (existing) {
-      if (this._session && this._session !== existing.session) {
-        const oldSp = this._session.sessionManager?.getSessionFile?.();
-        if (oldSp) {
-          const oldEntry = this._sessions.get(oldSp);
-          const oldAgent = oldEntry ? this._d.getAgentById(oldEntry.agentId) : this._d.getAgent();
-          await notifyMemorySessionEnd(oldAgent, oldSp, "session switch");
-        }
-      }
-      this._session = existing.session;
-      existing.lastTouchedAt = Date.now();
-      const targetAgent = this._d.getAgentById(existing.agentId) || this._d.getAgent();
-      targetAgent.setMemoryEnabled(memoryEnabled);
-      return existing.session;
+      const activeSession = await prepareCachedSessionSwitch({
+        activeSession: this._session,
+        targetEntry: existing,
+        sessions: this._sessions,
+        memoryEnabled,
+        getAgentById: (agentId) => this._d.getAgentById(agentId),
+        getFallbackAgent: () => this._d.getAgent(),
+        notifySessionEnd: notifyMemorySessionEnd,
+      });
+      this._session = activeSession;
+      return activeSession;
     }
 
     // 不在 map 中，先 flush 当前再新建
-    if (this._session) {
-      const oldSp = this._session.sessionManager?.getSessionFile?.();
-      if (oldSp) {
-        const oldEntry = this._sessions.get(oldSp);
-        const oldAgent = oldEntry ? this._d.getAgentById(oldEntry.agentId) : this._d.getAgent();
-        await notifyMemorySessionEnd(oldAgent, oldSp, "cold session switch");
-      }
-    }
+    await notifyActiveSessionEnd({
+      activeSession: this._session,
+      sessions: this._sessions,
+      getAgentById: (agentId) => this._d.getAgentById(agentId),
+      getFallbackAgent: () => this._d.getAgent(),
+      notifySessionEnd: notifyMemorySessionEnd,
+      context: "cold session switch",
+    });
+
     // 冷启动恢复：从 session-meta.json 解析 model，传给 createSession
-    let savedModel: ModelLike = null;
-    if (savedModelRef) {
-      const models = this._d.getModels();
-      savedModel = findModel(models.availableModels, savedModelRef.id, savedModelRef.provider || undefined);
-      if (!savedModel) {
-        log.warn(`cold-start model not found (${savedModelRef.id}), using agent default`);
-      }
-    }
+    const savedModel = resolveColdStartSwitchModel({
+      savedModelRef,
+      availableModels: this._d.getModels().availableModels,
+      onMissingModel: (modelRef) => log.warn(`cold-start model not found (${modelRef.id}), using agent default`),
+    });
     const sessionMgr = SessionManager.open(sessionPath, this._d.getAgent().sessionDir);
     const cwd = sessionMgr.getCwd?.() || undefined;
     return this.createSession(sessionMgr, cwd, memoryEnabled, savedModel);

--- a/core/session-switch-meta.ts
+++ b/core/session-switch-meta.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-type ModelRef = { id: string; provider?: string };
+export type ModelRef = { id: string; provider?: string };
 
 export function readSessionSwitchMeta(opts: {
   sessionPath: string;

--- a/core/session-switch-runtime.ts
+++ b/core/session-switch-runtime.ts
@@ -1,0 +1,74 @@
+import { findModel } from "../shared/model-ref.js";
+import type { ResolvedModel } from "./types.js";
+import type { ModelRef } from "./session-switch-meta.js";
+
+type AnyRecord = Record<string, any>;
+type AgentLike = AnyRecord;
+type SessionLike = AnyRecord;
+type ModelLike = ResolvedModel | AnyRecord | null;
+type AvailableModelLike = (ResolvedModel | AnyRecord) & { id: string };
+
+export type SwitchSessionEntry = AnyRecord & {
+  session: SessionLike;
+  agentId: string;
+  lastTouchedAt: number;
+};
+
+export async function notifyActiveSessionEnd(opts: {
+  activeSession: SessionLike | null | undefined;
+  sessions: Map<string, SwitchSessionEntry>;
+  getAgentById: (agentId: string) => AgentLike | null | undefined;
+  getFallbackAgent: () => AgentLike;
+  notifySessionEnd: (agent: AgentLike | null | undefined, sessionPath: string, context: string) => void | Promise<void>;
+  context: string;
+}) {
+  const oldSessionPath = opts.activeSession?.sessionManager?.getSessionFile?.();
+  if (!oldSessionPath) return;
+
+  const oldEntry = opts.sessions.get(oldSessionPath);
+  const oldAgent = oldEntry ? opts.getAgentById(oldEntry.agentId) : opts.getFallbackAgent();
+  await opts.notifySessionEnd(oldAgent, oldSessionPath, opts.context);
+}
+
+export async function prepareCachedSessionSwitch(opts: {
+  activeSession: SessionLike | null | undefined;
+  targetEntry: SwitchSessionEntry;
+  sessions: Map<string, SwitchSessionEntry>;
+  memoryEnabled: boolean;
+  getAgentById: (agentId: string) => AgentLike | null | undefined;
+  getFallbackAgent: () => AgentLike;
+  notifySessionEnd: (agent: AgentLike | null | undefined, sessionPath: string, context: string) => void | Promise<void>;
+  now?: () => number;
+}) {
+  if (opts.activeSession && opts.activeSession !== opts.targetEntry.session) {
+    await notifyActiveSessionEnd({
+      activeSession: opts.activeSession,
+      sessions: opts.sessions,
+      getAgentById: opts.getAgentById,
+      getFallbackAgent: opts.getFallbackAgent,
+      notifySessionEnd: opts.notifySessionEnd,
+      context: "session switch",
+    });
+  }
+
+  opts.targetEntry.lastTouchedAt = opts.now?.() ?? Date.now();
+  const targetAgent = opts.getAgentById(opts.targetEntry.agentId) || opts.getFallbackAgent();
+  targetAgent.setMemoryEnabled?.(opts.memoryEnabled);
+  return opts.targetEntry.session;
+}
+
+export function resolveColdStartSwitchModel(opts: {
+  savedModelRef: ModelRef | null;
+  availableModels: AvailableModelLike[];
+  onMissingModel?: (modelRef: ModelRef) => void;
+}) {
+  if (!opts.savedModelRef) return null;
+
+  const model = findModel(
+    opts.availableModels,
+    opts.savedModelRef.id,
+    opts.savedModelRef.provider || undefined,
+  ) as ModelLike;
+  if (!model) opts.onMissingModel?.(opts.savedModelRef);
+  return model;
+}

--- a/tests/session-switch-runtime.test.js
+++ b/tests/session-switch-runtime.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  notifyActiveSessionEnd,
+  prepareCachedSessionSwitch,
+  resolveColdStartSwitchModel,
+} from "../core/session-switch-runtime.js";
+
+describe("session switch runtime helpers", () => {
+  it("notifies the owner agent for the active session being left", async () => {
+    const oldSession = { sessionManager: { getSessionFile: () => "/tmp/old.jsonl" } };
+    const ownerAgent = { id: "owner" };
+    const fallbackAgent = { id: "fallback" };
+    const notifySessionEnd = vi.fn();
+
+    await notifyActiveSessionEnd({
+      activeSession: oldSession,
+      sessions: new Map([["/tmp/old.jsonl", { agentId: "agent-a", session: oldSession, lastTouchedAt: 1 }]]),
+      getAgentById: (agentId) => agentId === "agent-a" ? ownerAgent : null,
+      getFallbackAgent: () => fallbackAgent,
+      notifySessionEnd,
+      context: "session switch",
+    });
+
+    expect(notifySessionEnd).toHaveBeenCalledWith(ownerAgent, "/tmp/old.jsonl", "session switch");
+  });
+
+  it("activates a cached target session and restores its memory toggle", async () => {
+    const oldSession = { sessionManager: { getSessionFile: () => "/tmp/old.jsonl" } };
+    const newSession = { sessionManager: { getSessionFile: () => "/tmp/new.jsonl" } };
+    const targetAgent = { setMemoryEnabled: vi.fn() };
+    const notifySessionEnd = vi.fn();
+    const targetEntry = { agentId: "agent-b", session: newSession, lastTouchedAt: 1 };
+
+    const result = await prepareCachedSessionSwitch({
+      activeSession: oldSession,
+      targetEntry,
+      sessions: new Map([
+        ["/tmp/old.jsonl", { agentId: "agent-a", session: oldSession, lastTouchedAt: 1 }],
+        ["/tmp/new.jsonl", targetEntry],
+      ]),
+      memoryEnabled: false,
+      getAgentById: (agentId) => agentId === "agent-b" ? targetAgent : { id: agentId },
+      getFallbackAgent: () => ({ id: "fallback" }),
+      notifySessionEnd,
+      now: () => 42,
+    });
+
+    expect(result).toBe(newSession);
+    expect(targetEntry.lastTouchedAt).toBe(42);
+    expect(targetAgent.setMemoryEnabled).toHaveBeenCalledWith(false);
+    expect(notifySessionEnd).toHaveBeenCalledWith({ id: "agent-a" }, "/tmp/old.jsonl", "session switch");
+  });
+
+  it("resolves saved cold-start models and reports missing refs", () => {
+    const model = { id: "qwen", provider: "local", name: "Qwen" };
+    expect(resolveColdStartSwitchModel({
+      savedModelRef: { id: "qwen", provider: "local" },
+      availableModels: [model],
+    })).toBe(model);
+
+    const onMissingModel = vi.fn();
+    expect(resolveColdStartSwitchModel({
+      savedModelRef: { id: "missing", provider: "local" },
+      availableModels: [model],
+      onMissingModel,
+    })).toBeNull();
+    expect(onMissingModel).toHaveBeenCalledWith({ id: "missing", provider: "local" });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract cached-session activation and active-session end notification from `switchSession`
- Move cold-start saved-model resolution behind `resolveColdStartSwitchModel`
- Add helper-level coverage for session-end notification, cached switch activation, memory toggle restore, and missing saved-model refs

## Validation
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npm test -- --reporter=dot tests/session-switch-runtime.test.js tests/session-switch-meta.test.js tests/session-coordinator.test.js tests/model-no-fallback.test.js`
- `npm run release:gate`
