### PR TITLE
refactor(session): extract prompt integrity runner

### DIFF
--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -39,8 +39,7 @@ import {
   toSessionPromptOptions,
 } from "./session-context-hints.js";
 import {
-  createReplyIntegrityTracker,
-  ensureValidReplyExecution,
+  runPromptWithIntegrity,
   sanitizeActiveSessionContextForPrompt,
 } from "./session-prompt-sanitizer.js";
 import {
@@ -522,19 +521,9 @@ export class SessionCoordinator {
     const _promptOpts = toSessionPromptOptions(opts?.images);
     sanitizeActiveSessionContextForPrompt(this._session, sp);
     const runPromptAttempt = async (attemptText: string) => {
-      const tracker = createReplyIntegrityTracker();
       const activeSession = this._session;
       if (!activeSession) throw new Error(t("error.noActiveSessionPrompt"));
-      const unsub = activeSession.subscribe((event: AnyRecord) => {
-        tracker.handle(event);
-      });
-      try {
-        await activeSession.prompt(attemptText, _promptOpts);
-        ensureValidReplyExecution(tracker);
-        return tracker.replyText;
-      } finally {
-        unsub?.();
-      }
+      return runPromptWithIntegrity(activeSession, attemptText, _promptOpts, { passOptionsArgument: true });
     };
     try {
       const entry = sp ? this._sessions.get(sp) : null;
@@ -611,17 +600,7 @@ export class SessionCoordinator {
     const _promptOpts = toSessionPromptOptions(opts?.images);
     sanitizeActiveSessionContextForPrompt(entry.session, sessionPath);
     const runPromptAttempt = async (attemptText: string) => {
-      const tracker = createReplyIntegrityTracker();
-      const unsub = entry.session.subscribe((event: AnyRecord) => {
-        tracker.handle(event);
-      });
-      try {
-        await entry.session.prompt(attemptText, _promptOpts);
-        ensureValidReplyExecution(tracker);
-        return tracker.replyText;
-      } finally {
-        unsub?.();
-      }
+      return runPromptWithIntegrity(entry.session, attemptText, _promptOpts, { passOptionsArgument: true });
     };
     try {
       if (opts?.disableTools) {
@@ -1095,20 +1074,6 @@ export class SessionCoordinator {
         ...(clientAgentMetadata && { requestMetadata: clientAgentMetadata }),
       } as any);
 
-      const runPromptAttempt = async (attemptPrompt: string) => {
-        const tracker = createReplyIntegrityTracker();
-        const unsub = session.subscribe((event: AnyRecord) => {
-          tracker.handle(event);
-        });
-        try {
-          await session.prompt(attemptPrompt);
-          ensureValidReplyExecution(tracker);
-          return tracker.replyText;
-        } finally {
-          unsub?.();
-        }
-      };
-
       // abort signal：监听中止，转发到子 session
       const abortHandler = () => session.abort();
       opts.signal?.addEventListener("abort", abortHandler, { once: true });
@@ -1122,7 +1087,7 @@ export class SessionCoordinator {
 
       let replyText = "";
       try {
-        replyText = await runPromptAttempt(prompt);
+        replyText = await runPromptWithIntegrity(session, prompt);
       } finally {
         opts.signal?.removeEventListener("abort", abortHandler);
       }

--- a/core/session-prompt-sanitizer.ts
+++ b/core/session-prompt-sanitizer.ts
@@ -109,3 +109,26 @@ export function createReplyIntegrityTracker() {
 export function ensureValidReplyExecution(_tracker: ReturnType<typeof createReplyIntegrityTracker>) {
   return;
 }
+
+export async function runPromptWithIntegrity(
+  session: SessionLike,
+  text: string,
+  promptOptions?: unknown,
+  opts: { passOptionsArgument?: boolean } = {},
+) {
+  const tracker = createReplyIntegrityTracker();
+  const unsub = session.subscribe((event: AnyRecord) => {
+    tracker.handle(event);
+  });
+  try {
+    if (opts.passOptionsArgument || promptOptions !== undefined) {
+      await session.prompt(text, promptOptions);
+    } else {
+      await session.prompt(text);
+    }
+    ensureValidReplyExecution(tracker);
+    return tracker.replyText;
+  } finally {
+    unsub?.();
+  }
+}

--- a/tests/session-prompt-sanitizer.test.js
+++ b/tests/session-prompt-sanitizer.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { runPromptWithIntegrity } from "../core/session-prompt-sanitizer.js";
+
+describe("session prompt sanitizer helpers", () => {
+  it("runs a prompt while collecting assistant text deltas", async () => {
+    let handler = null;
+    const unsub = vi.fn();
+    const session = {
+      subscribe: vi.fn((fn) => {
+        handler = fn;
+        return unsub;
+      }),
+      prompt: vi.fn(async () => {
+        handler?.({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hello" } });
+        handler?.({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: " world" } });
+      }),
+    };
+
+    await expect(runPromptWithIntegrity(session, "hi", { images: [] })).resolves.toBe("hello world");
+    expect(session.prompt).toHaveBeenCalledWith("hi", { images: [] });
+    expect(unsub).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribes when prompt throws", async () => {
+    const unsub = vi.fn();
+    const session = {
+      subscribe: vi.fn(() => unsub),
+      prompt: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    };
+
+    await expect(runPromptWithIntegrity(session, "hi")).rejects.toThrow("boom");
+    expect(session.prompt).toHaveBeenCalledWith("hi");
+    expect(unsub).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract duplicated prompt subscription / reply integrity handling into `runPromptWithIntegrity`
- Reuse the helper across active chat, path-aware promptSession, and isolated execution prompts
- Preserve existing `session.prompt(text, undefined)` call shape where the normal chat path expects it

## Validation
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npm test -- --reporter=dot tests/session-prompt-sanitizer.test.js tests/session-coordinator.test.js tests/model-no-fallback.test.js`
- `npm run release:gate`
