### PR TITLE
refactor(session): extract prompt image option helper

### DIFF
--- a/core/session-context-hints.ts
+++ b/core/session-context-hints.ts
@@ -71,6 +71,14 @@ export function toSessionPromptOptions(images?: PromptImage[]) {
   };
 }
 
+export function stripUnsupportedPromptImagesForModel(opts: { images?: PromptImage[] } | null | undefined, modelOwner: AnyRecord, resolveModelOverrides?: (model: unknown, overrides: unknown) => AnyRecord | null | undefined) {
+  const resolved = resolveModelOverrides?.(modelOwner?.model, modelOwner?.config?.models?.overrides);
+  if (opts?.images?.length && resolved?.vision === false) {
+    opts.images = undefined;
+  }
+  return opts?.images;
+}
+
 function buildSkillToolCompatibilityHint(skillName: string | null | undefined) {
   const isZh = getLocale().startsWith("zh");
   const toolNames = "read, write, edit, bash, grep, find, ls";

--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -36,6 +36,7 @@ import {
 } from "../shared/model-tool-capabilities.js";
 import {
   getSteerPrefix,
+  stripUnsupportedPromptImagesForModel,
   toSessionPromptOptions,
 } from "./session-context-hints.js";
 import {
@@ -511,14 +512,10 @@ export class SessionCoordinator {
       }
     }
 
-    // 非 vision 模型：静默剥离图片，只发文字（与 bridge-session-manager 保持一致）
-    const _resolved = this._d.resolveModelOverrides?.(agent.model, agent.config?.models?.overrides);
-    if (opts?.images?.length && _resolved?.vision === false) {
-      opts.images = undefined;
-    }
     // [VISION-ARG-FIX v0.76.6] 当前 session.prompt() 使用 options 形态，
     // 图片需转为 { images: [{ type: "image", source: { type: "base64", mediaType, data } }] }。
-    const _promptOpts = toSessionPromptOptions(opts?.images);
+    // 非 vision 模型：静默剥离图片，只发文字（与 bridge-session-manager 保持一致）
+    const _promptOpts = toSessionPromptOptions(stripUnsupportedPromptImagesForModel(opts, agent, this._d.resolveModelOverrides));
     sanitizeActiveSessionContextForPrompt(this._session, sp);
     const runPromptAttempt = async (attemptText: string) => {
       const activeSession = this._session;
@@ -591,13 +588,9 @@ export class SessionCoordinator {
     });
 
     if (sessionPath === this.currentSessionPath) this._sessionStarted = true;
-    // 非 vision 模型：静默剥离图片（与 bridge-session-manager 保持一致）
-    const _resolvedSub = this._d.resolveModelOverrides?.(agent.model, agent.config?.models?.overrides);
-    if (opts?.images?.length && _resolvedSub?.vision === false) {
-      opts.images = undefined;
-    }
     // [VISION-ARG-FIX v0.76.6] session.prompt() 需要 options.images，且图片块走 source.base64。
-    const _promptOpts = toSessionPromptOptions(opts?.images);
+    // 非 vision 模型：静默剥离图片（与 bridge-session-manager 保持一致）
+    const _promptOpts = toSessionPromptOptions(stripUnsupportedPromptImagesForModel(opts, agent, this._d.resolveModelOverrides));
     sanitizeActiveSessionContextForPrompt(entry.session, sessionPath);
     const runPromptAttempt = async (attemptText: string) => {
       return runPromptWithIntegrity(entry.session, attemptText, _promptOpts, { passOptionsArgument: true });

--- a/tests/session-context-hints.test.js
+++ b/tests/session-context-hints.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { stripUnsupportedPromptImagesForModel, toSessionPromptOptions } from "../core/session-context-hints.js";
+
+describe("session context hint prompt option helpers", () => {
+  it("keeps images for vision-capable models and builds pi prompt options", () => {
+    const opts = { images: [{ data: "abc", mimeType: "image/jpeg" }] };
+    const images = stripUnsupportedPromptImagesForModel(
+      opts,
+      { model: { id: "vision" }, config: { models: { overrides: {} } } },
+      () => ({ vision: true }),
+    );
+
+    expect(images).toEqual(opts.images);
+    expect(toSessionPromptOptions(images)).toEqual({
+      images: [{
+        type: "image",
+        data: "abc",
+        mimeType: "image/jpeg",
+        source: { type: "base64", mediaType: "image/jpeg", data: "abc" },
+      }],
+    });
+  });
+
+  it("strips images in-place for non-vision models", () => {
+    const opts = { images: [{ data: "abc" }] };
+    const images = stripUnsupportedPromptImagesForModel(
+      opts,
+      { model: { id: "text" }, config: { models: { overrides: {} } } },
+      () => ({ vision: false }),
+    );
+
+    expect(images).toBeUndefined();
+    expect(opts.images).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Extract non-vision image stripping into `stripUnsupportedPromptImagesForModel`
- Keep `toSessionPromptOptions(...)` as the canonical Pi prompt image conversion at both chat call sites
- Add helper tests covering vision-capable and text-only model behavior

## Validation
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npm test -- --reporter=dot tests/session-context-hints.test.js tests/session-prompt-sanitizer.test.js tests/session-coordinator.test.js tests/model-no-fallback.test.js tests/vision-arg-regression.test.js`
- `npm run release:gate`
