### PR TITLE
refactor(session): extract context factory

### DIFF
--- a/core/session-context-factory.ts
+++ b/core/session-context-factory.ts
@@ -1,0 +1,85 @@
+import { findModel } from "../shared/model-ref.js";
+import { getUserFacingRoleModelLabel, resolveRoleDefaultModel } from "../shared/assistant-role-models.js";
+
+type AnyRecord = Record<string, any>;
+type ToolLike = AnyRecord & { name: string };
+
+function shouldExposeVerboseModelRouting() {
+  const flag = String(process?.env?.LYNN_DEBUG_MODELS || process?.env?.DEBUG_MODEL_ROUTING || "").trim().toLowerCase();
+  return flag === "1" || flag === "true" || process?.env?.NODE_ENV === "development";
+}
+
+export function resolveSessionContextModel(agentConfig: AnyRecord, opts: {
+  models: AnyRecord;
+  log: Pick<Console, "log" | "error">;
+  t: (key: string, vars?: AnyRecord) => string;
+}) {
+  const { models, log, t } = opts;
+  const chatRef = agentConfig?.models?.chat;
+  const agentRole = agentConfig?.agent?.yuan || null;
+  const roleLabel = getUserFacingRoleModelLabel(agentRole, "chat") || "角色默认模型";
+  const id = typeof chatRef === "object" ? chatRef?.id : chatRef;
+  const provider = typeof chatRef === "object" ? chatRef?.provider : undefined;
+
+  // 非 active agent 可能没有配 models.chat（模板默认为空），回退到全局默认模型
+  if (!id) {
+    const roleDefaultModel = resolveRoleDefaultModel(models.availableModels, agentRole);
+    if (roleDefaultModel) {
+      log.log(`[resolveModel] agentConfig 未指定 models.chat，按角色回退到 ${roleLabel}`);
+      return roleDefaultModel;
+    }
+    if (models.defaultModel) {
+      log.log("[resolveModel] agentConfig 未指定 models.chat，回退到默认模型");
+      return models.defaultModel;
+    }
+    log.error("[resolveModel] agentConfig 未指定 models.chat，也没有默认模型");
+    throw new Error(t("error.resolveModelNoChatModel"));
+  }
+
+  const found = findModel(models.availableModels, id, provider);
+  if (found) return found;
+
+  // 模型 ID 在可用列表中找不到，尝试回退到默认模型
+  const roleDefaultModel = resolveRoleDefaultModel(models.availableModels, agentRole);
+  if (roleDefaultModel) {
+    log.log(`[resolveModel] 已配置聊天模型暂不可用，按角色回退到 ${roleLabel}`);
+    return roleDefaultModel;
+  }
+  if (models.defaultModel) {
+    log.log("[resolveModel] 已配置聊天模型暂不可用，回退到默认模型");
+    return models.defaultModel;
+  }
+  if (shouldExposeVerboseModelRouting()) {
+    const available = models.availableModels.map((m: AnyRecord) => `${m.provider}/${m.id}`).join(", ");
+    const hasAuth = models.modelRegistry
+      ? `hasAuth("${models.inferModelProvider?.(id) || "?"}")=unknown`
+      : "no registry";
+    log.error(`[resolveModel] 找不到模型 "${id}"。availableModels=[${available}]。${hasAuth}`);
+  } else {
+    log.error("[resolveModel] 找不到可用聊天模型，且默认回退链不可用");
+  }
+  throw new Error(t("error.resolveModelNotAvailable", { id }));
+}
+
+export function createSessionContextFactory(opts: {
+  models: AnyRecord;
+  skills: AnyRecord;
+  resourceLoader: AnyRecord;
+  buildTools: (cwd: string, customTools?: unknown, opts?: AnyRecord) => { tools: ToolLike[]; customTools: ToolLike[] };
+  log: Pick<Console, "log" | "error">;
+  t: (key: string, vars?: AnyRecord) => string;
+}) {
+  return {
+    authStorage: opts.models.authStorage,
+    modelRegistry: opts.models.modelRegistry,
+    resourceLoader: opts.resourceLoader,
+    allSkills: opts.skills.allSkills,
+    getSkillsForAgent: (agent: AnyRecord) => opts.skills.getSkillsForAgent?.(agent) || [],
+    buildTools: (cwd: string, customTools?: unknown, buildOpts?: AnyRecord) => opts.buildTools(cwd, customTools, buildOpts),
+    resolveModel: (agentConfig: AnyRecord) => resolveSessionContextModel(agentConfig, {
+      models: opts.models,
+      log: opts.log,
+      t: opts.t,
+    }),
+  };
+}

--- a/core/session-coordinator.ts
+++ b/core/session-coordinator.ts
@@ -27,7 +27,6 @@ import {
   readSignedClientAgentHeaders,
 } from "./client-agent-identity.js";
 import { resolveCompactionSettings } from "./compaction-settings.js";
-import { getUserFacingRoleModelLabel, resolveRoleDefaultModel } from "../shared/assistant-role-models.js";
 import {
   ROUTE_INTENTS,
 } from "../shared/task-route-intent.js";
@@ -90,6 +89,7 @@ import {
   clearSessionTurnContext,
   prepareSessionTurnContext,
 } from "./session-turn-context.js";
+import { createSessionContextFactory } from "./session-context-factory.js";
 import { readSessionSwitchMeta } from "./session-switch-meta.js";
 import {
   notifyActiveSessionEnd,
@@ -173,11 +173,6 @@ function notifyMemorySessionEnd(agent: AgentLike | null | undefined, sessionPath
   const promise = agent?._memoryTicker?.notifySessionEnd(sessionPath);
   if (!promise?.catch) return promise;
   return promise.catch((err: unknown) => warnMemoryNotifySessionEnd(context, sessionPath, err));
-}
-
-function shouldExposeVerboseModelRouting() {
-  const flag = String(process?.env?.LYNN_DEBUG_MODELS || process?.env?.DEBUG_MODEL_ROUTING || "").trim().toLowerCase();
-  return flag === "1" || flag === "true" || process?.env?.NODE_ENV === "development";
 }
 
 export class SessionCoordinator {
@@ -912,59 +907,14 @@ export class SessionCoordinator {
   createSessionContext() {
     const models = this._d.getModels();
     const skills = this._d.getSkills?.() || {};
-    return {
-      authStorage:    models.authStorage,
-      modelRegistry:  models.modelRegistry,
+    return createSessionContextFactory({
+      models,
+      skills,
       resourceLoader: this._d.getResourceLoader(),
-      allSkills:      skills.allSkills,
-      getSkillsForAgent: (ag: AgentLike) => skills.getSkillsForAgent?.(ag) || [],
-      buildTools:     (cwd: string, customTools?: unknown, opts?: AnyRecord) => this._d.buildTools(cwd, customTools, opts),
-      resolveModel:   (agentConfig: AnyRecord) => {
-        const chatRef = agentConfig?.models?.chat;
-        const agentRole = agentConfig?.agent?.yuan || null;
-        const roleLabel = getUserFacingRoleModelLabel(agentRole, "chat") || "角色默认模型";
-        const id = typeof chatRef === "object" ? chatRef?.id : chatRef;
-        const provider = typeof chatRef === "object" ? chatRef?.provider : undefined;
-        // 非 active agent 可能没有配 models.chat（模板默认为空），回退到全局默认模型
-        if (!id) {
-          const roleDefaultModel = resolveRoleDefaultModel(models.availableModels, agentRole);
-          if (roleDefaultModel) {
-            log.log(`[resolveModel] agentConfig 未指定 models.chat，按角色回退到 ${roleLabel}`);
-            return roleDefaultModel;
-          }
-          if (models.defaultModel) {
-            log.log(`[resolveModel] agentConfig 未指定 models.chat，回退到默认模型`);
-            return models.defaultModel;
-          }
-          log.error(`[resolveModel] agentConfig 未指定 models.chat，也没有默认模型`);
-          throw new Error(t("error.resolveModelNoChatModel"));
-        }
-        const found = findModel(models.availableModels, id, provider);
-        if (!found) {
-          // 模型 ID 在可用列表中找不到，尝试回退到默认模型
-          const roleDefaultModel = resolveRoleDefaultModel(models.availableModels, agentRole);
-          if (roleDefaultModel) {
-            log.log(`[resolveModel] 已配置聊天模型暂不可用，按角色回退到 ${roleLabel}`);
-            return roleDefaultModel;
-          }
-          if (models.defaultModel) {
-            log.log(`[resolveModel] 已配置聊天模型暂不可用，回退到默认模型`);
-            return models.defaultModel;
-          }
-          if (shouldExposeVerboseModelRouting()) {
-            const available = models.availableModels.map((m: AnyRecord) => `${m.provider}/${m.id}`).join(", ");
-            const hasAuth = models.modelRegistry
-              ? `hasAuth("${models.inferModelProvider?.(id) || "?"}")=unknown`
-              : "no registry";
-            log.error(`[resolveModel] 找不到模型 "${id}"。availableModels=[${available}]。${hasAuth}`);
-          } else {
-            log.error(`[resolveModel] 找不到可用聊天模型，且默认回退链不可用`);
-          }
-          throw new Error(t("error.resolveModelNotAvailable", { id }));
-        }
-        return found;
-      },
-    };
+      buildTools: (cwd, customTools, opts) => this._d.buildTools(cwd, customTools, opts),
+      log,
+      t,
+    });
   }
 
   promoteActivitySession(activitySessionFile: string) {

--- a/tests/session-context-factory.test.js
+++ b/tests/session-context-factory.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSessionContextFactory,
+  resolveSessionContextModel,
+} from "../core/session-context-factory.js";
+
+function makeModels(models, defaultModel = models[0] || null) {
+  return {
+    availableModels: models,
+    defaultModel,
+    authStorage: { kind: "auth" },
+    modelRegistry: { kind: "registry" },
+  };
+}
+
+describe("session context factory", () => {
+  it("creates the context shape consumed by agent sessions", () => {
+    const buildTools = vi.fn(() => ({ tools: [{ name: "read" }], customTools: [] }));
+    const skills = {
+      allSkills: [{ name: "skill" }],
+      getSkillsForAgent: vi.fn(() => [{ name: "agent-skill" }]),
+    };
+
+    const ctx = createSessionContextFactory({
+      models: makeModels([{ id: "m", provider: "p" }]),
+      skills,
+      resourceLoader: { getSystemPrompt: () => "prompt" },
+      buildTools,
+      log: { log: vi.fn(), error: vi.fn() },
+      t: (key) => key,
+    });
+
+    expect(ctx.authStorage).toEqual({ kind: "auth" });
+    expect(ctx.modelRegistry).toEqual({ kind: "registry" });
+    expect(ctx.allSkills).toEqual([{ name: "skill" }]);
+    expect(ctx.getSkillsForAgent({ id: "a" })).toEqual([{ name: "agent-skill" }]);
+    expect(ctx.buildTools("/tmp")).toEqual({ tools: [{ name: "read" }], customTools: [] });
+    expect(ctx.resolveModel({ models: { chat: "m" } })).toEqual({ id: "m", provider: "p" });
+  });
+
+  it("resolves configured provider-specific chat models", () => {
+    expect(resolveSessionContextModel({
+      models: { chat: { id: "same", provider: "b" } },
+    }, {
+      models: makeModels([
+        { id: "same", provider: "a" },
+        { id: "same", provider: "b" },
+      ]),
+      log: { log: vi.fn(), error: vi.fn() },
+      t: (key) => key,
+    })).toEqual({ id: "same", provider: "b" });
+  });
+
+  it("falls back to default model when chat ref is missing or unavailable", () => {
+    const defaultModel = { id: "default", provider: "brain" };
+    const opts = {
+      models: makeModels([defaultModel], defaultModel),
+      log: { log: vi.fn(), error: vi.fn() },
+      t: (key) => key,
+    };
+
+    expect(resolveSessionContextModel({}, opts)).toBe(defaultModel);
+    expect(resolveSessionContextModel({ models: { chat: "missing" } }, opts)).toBe(defaultModel);
+  });
+
+  it("throws translated errors when no fallback exists", () => {
+    const opts = {
+      models: makeModels([], null),
+      log: { log: vi.fn(), error: vi.fn() },
+      t: (key, vars) => `${key}:${vars?.id || ""}`,
+    };
+
+    expect(() => resolveSessionContextModel({}, opts)).toThrow("error.resolveModelNoChatModel");
+    expect(() => resolveSessionContextModel({ models: { chat: "missing" } }, opts))
+      .toThrow("error.resolveModelNotAvailable:missing");
+  });
+});


### PR DESCRIPTION
## Summary
- extract `SessionCoordinator.createSessionContext()` model/context construction into `core/session-context-factory.ts`
- keep role-default and default-model fallback behavior intact
- add focused regression coverage for context shape, provider-specific model lookup, fallback, and translated errors

## Validation
- `npm test -- --reporter=dot tests/session-context-factory.test.js tests/model-no-fallback.test.js tests/session-coordinator.test.js`
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npm run release:gate`
