### PR TITLE
fix(brain-v2): suppress repeated server tool storms

### DIFF
--- a/brain-v2-mirror/__tests__/router.test.js
+++ b/brain-v2-mirror/__tests__/router.test.js
@@ -50,6 +50,9 @@ afterEach(() => {
   vi.unstubAllGlobals();
   delete process.env.BRAIN_V2_PRE_SEARCH;
   delete process.env.MIMO_SEARCH_KEY;
+  delete process.env.BRAIN_V2_STORM_DETECT;
+  delete process.env.BRAIN_V2_STORM_THRESHOLD;
+  delete process.env.BRAIN_V2_STORM_MAX;
 });
 
 describe('Router', () => {
@@ -223,6 +226,45 @@ describe('Router', () => {
     expect(adapterMessages[0].role).toBe('system');
     expect(String(adapterMessages[0].content)).toContain('【实时信息上下文】');
     expect(adapterMessages[1].role).toBe('user');
+  });
+
+  it('suppresses repeated server tool calls when storm detection is enabled', async () => {
+    process.env.BRAIN_V2_STORM_DETECT = '1';
+    process.env.BRAIN_V2_STORM_THRESHOLD = '2';
+    process.env.BRAIN_V2_STORM_MAX = '3';
+    let adapterRuns = 0;
+    mockState.adapterFn = async function* () {
+      adapterRuns += 1;
+      yield {
+        type: 'tool_call_delta',
+        delta: [{
+          index: 0,
+          id: `tc-${adapterRuns}`,
+          type: 'function',
+          function: { name: 'unit_convert', arguments: '{"query":"100公里"}' },
+        }],
+      };
+      yield { type: 'finish', reason: 'tool_calls' };
+    };
+
+    const chunks = [];
+    const result = await run({
+      messages: [{ role: 'user', content: '重复换算测试' }],
+      onChunk: async (chunk) => chunks.push(chunk),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: 'tool_storm_limit',
+      providerId: 'p-mimo',
+      iterations: 4,
+    });
+    expect(adapterRuns).toBe(4);
+    expect(chunks.filter(c => c.type === 'error')).toEqual([
+      expect.objectContaining({ error: 'tool_storm_limit', tool: 'unit_convert', storms: 3 }),
+    ]);
+    expect(chunks.filter(c => c.type === 'tool_progress' && c.event === 'end').map(c => c.ok))
+      .toEqual([true, false, false, false]);
   });
 });
 

--- a/brain-v2-mirror/__tests__/tool-storm.test.js
+++ b/brain-v2-mirror/__tests__/tool-storm.test.js
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  buildToolStormReflection,
+  createToolStormState,
+  observeToolCallStorm,
+  readToolStormConfigFromEnv,
+  toolCallSignature,
+} from '../tool-storm.js';
+
+function toolCall(name, args) {
+  return {
+    id: 'tc-1',
+    type: 'function',
+    function: {
+      name,
+      arguments: typeof args === 'string' ? args : JSON.stringify(args),
+    },
+  };
+}
+
+afterEach(() => {
+  delete process.env.BRAIN_V2_STORM_DETECT;
+  delete process.env.BRAIN_V2_STORM_THRESHOLD;
+  delete process.env.BRAIN_V2_STORM_WINDOW;
+  delete process.env.BRAIN_V2_STORM_MAX;
+});
+
+describe('tool storm guard', () => {
+  it('keeps signatures stable for equivalent JSON argument order', () => {
+    expect(toolCallSignature('web_search', '{"query":"杭州天气","limit":3}'))
+      .toBe(toolCallSignature('web_search', '{"limit":3,"query":"杭州天气"}'));
+  });
+
+  it('defaults to disabled unless explicitly enabled', () => {
+    expect(readToolStormConfigFromEnv()).toMatchObject({
+      enabled: false,
+      threshold: 2,
+      windowSize: 3,
+      maxStorms: 3,
+    });
+  });
+
+  it('suppresses repeated identical tool calls when enabled', () => {
+    const state = createToolStormState();
+    const config = { enabled: true, threshold: 2, windowSize: 3, maxStorms: 3 };
+
+    const first = observeToolCallStorm(state, toolCall('unit_convert', { query: '100公里' }), config);
+    const second = observeToolCallStorm(state, toolCall('unit_convert', { query: '100公里' }), config);
+
+    expect(first.storm).toBe(false);
+    expect(second).toMatchObject({
+      storm: true,
+      seen: 2,
+      stormCount: 1,
+      maxStormsReached: false,
+    });
+  });
+
+  it('does not suppress changed arguments inside the sliding window', () => {
+    const state = createToolStormState();
+    const config = { enabled: true, threshold: 2, windowSize: 3, maxStorms: 3 };
+
+    observeToolCallStorm(state, toolCall('unit_convert', { query: '100公里' }), config);
+    const changed = observeToolCallStorm(state, toolCall('unit_convert', { query: '200公里' }), config);
+
+    expect(changed.storm).toBe(false);
+  });
+
+  it('reports maxStormsReached after repeated suppressed calls', () => {
+    const state = createToolStormState();
+    const config = { enabled: true, threshold: 2, windowSize: 3, maxStorms: 2 };
+
+    observeToolCallStorm(state, toolCall('unit_convert', { query: '100公里' }), config);
+    const second = observeToolCallStorm(state, toolCall('unit_convert', { query: '100公里' }), config);
+    const third = observeToolCallStorm(state, toolCall('unit_convert', { query: '100公里' }), config);
+
+    expect(second.maxStormsReached).toBe(false);
+    expect(third).toMatchObject({ storm: true, stormCount: 2, maxStormsReached: true });
+  });
+
+  it('builds a tool-role reflection payload for the model', () => {
+    const state = createToolStormState();
+    const config = { enabled: true, threshold: 2, windowSize: 3, maxStorms: 3 };
+    observeToolCallStorm(state, toolCall('web_search', { query: '杭州天气' }), config);
+    const verdict = observeToolCallStorm(state, toolCall('web_search', { query: '杭州天气' }), config);
+    const payload = JSON.parse(buildToolStormReflection(verdict));
+
+    expect(payload).toMatchObject({
+      ok: false,
+      error: 'tool_call_storm_suppressed',
+      tool: 'web_search',
+      repeat_count: 2,
+    });
+    expect(payload.message).toContain('Do not call it again');
+  });
+});

--- a/brain-v2-mirror/router.ts
+++ b/brain-v2-mirror/router.ts
@@ -10,6 +10,12 @@ import { getAdapter } from './wire-adapter/index.js';
 import { isServerTool, executeServerTool, mergeWithServerTools } from './tool-exec/index.js';
 import { applySearchContext, createSearchRequestCache, type SearchRequestCache } from './search-context.js';
 import { applyAudioTranscribe, createAudioRequestCache, type AudioRequestCache } from './audio-transcribe.js';
+import {
+  buildToolStormReflection,
+  createToolStormState,
+  observeToolCallStorm,
+  readToolStormConfigFromEnv,
+} from './tool-storm.js';
 import { errorMessage, type ChatMessage, type FallbackEntry, type Provider, type ProviderCapability, type ProviderId, type RouterRunOptions, type RouterRunResult, type ToolCall } from './types.js';
 
 type CapabilityRequired = Partial<Pick<ProviderCapability, 'vision' | 'audio' | 'video'>>;
@@ -260,6 +266,8 @@ export async function run({ messages, tools, capabilityRequired, signal, onChunk
   const maxIter = MAX_ITERATIONS > 0 ? MAX_ITERATIONS : Infinity;
   const requestCache = createSearchRequestCache();
   const audioCache = createAudioRequestCache() as AudioRequestCache;
+  const toolStormConfig = readToolStormConfigFromEnv();
+  const toolStormState = createToolStormState();
 
   while (iter < maxIter) {
     iter++;
@@ -299,6 +307,36 @@ export async function run({ messages, tools, capabilityRequired, signal, onChunk
       tool_calls: result.toolCalls,
     });
     for (const tc of serverCalls) {
+      const stormVerdict = observeToolCallStorm(toolStormState, tc, toolStormConfig);
+      if (stormVerdict.storm) {
+        log && log('warn', `tool storm suppressed: ${stormVerdict.toolName} repeat=${stormVerdict.seen} storms=${stormVerdict.stormCount}/${toolStormConfig.maxStorms}`);
+        await onChunk(
+          { type: 'tool_progress', event: 'start', name: tc.function.name },
+          { providerId: lastProviderId }
+        );
+        await onChunk(
+          { type: 'tool_progress', event: 'end', name: tc.function.name, ms: 0, ok: false },
+          { providerId: lastProviderId }
+        );
+        workingMessages.push({
+          role: 'tool',
+          tool_call_id: tc.id || ('tc-' + Math.random().toString(36).slice(2)),
+          content: buildToolStormReflection(stormVerdict),
+        });
+        if (stormVerdict.maxStormsReached) {
+          await onChunk(
+            { type: 'error', error: 'tool_storm_limit', tool: stormVerdict.toolName, storms: stormVerdict.stormCount },
+            { providerId: lastProviderId }
+          );
+          return {
+            ok: false,
+            providerId: lastProviderId,
+            iterations: iter,
+            error: 'tool_storm_limit',
+          };
+        }
+        continue;
+      }
       const t0 = Date.now();
       // 工具进度通过自定义 chunk type 表达,不污染 content stream (F5 fix)
       // Lynn UI 消费 type=tool_progress;非 Lynn 客户端 ignored。

--- a/brain-v2-mirror/tool-storm.ts
+++ b/brain-v2-mirror/tool-storm.ts
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto';
+import type { ToolCall } from './types.js';
+
+export type ToolStormConfig = {
+  enabled: boolean;
+  threshold: number;
+  windowSize: number;
+  maxStorms: number;
+};
+
+export type ToolStormEntry = {
+  signature: string;
+  toolName: string;
+};
+
+export type ToolStormState = {
+  history: ToolStormEntry[];
+  stormCount: number;
+};
+
+export type ToolStormVerdict = {
+  storm: boolean;
+  signature: string;
+  toolName: string;
+  seen: number;
+  stormCount: number;
+  maxStormsReached: boolean;
+};
+
+const DEFAULT_CONFIG: ToolStormConfig = {
+  enabled: false,
+  threshold: 2,
+  windowSize: 3,
+  maxStorms: 3,
+};
+
+function envFlag(name: string): boolean {
+  const value = String(process.env[name] || '').trim().toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
+function positiveInt(value: unknown, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map((item) => stableStringify(item)).join(',') + ']';
+  const obj = value as Record<string, unknown>;
+  return '{' + Object.keys(obj).sort().map((key) => (
+    JSON.stringify(key) + ':' + stableStringify(obj[key])
+  )).join(',') + '}';
+}
+
+function normalizeArgs(args: unknown): string {
+  if (typeof args !== 'string') return stableStringify(args ?? {});
+  const trimmed = args.trim();
+  if (!trimmed) return '{}';
+  try {
+    return stableStringify(JSON.parse(trimmed));
+  } catch {
+    return trimmed;
+  }
+}
+
+export function readToolStormConfigFromEnv(): ToolStormConfig {
+  return {
+    enabled: envFlag('BRAIN_V2_STORM_DETECT'),
+    threshold: positiveInt(process.env.BRAIN_V2_STORM_THRESHOLD, DEFAULT_CONFIG.threshold),
+    windowSize: positiveInt(process.env.BRAIN_V2_STORM_WINDOW, DEFAULT_CONFIG.windowSize),
+    maxStorms: positiveInt(process.env.BRAIN_V2_STORM_MAX, DEFAULT_CONFIG.maxStorms),
+  };
+}
+
+export function createToolStormState(): ToolStormState {
+  return { history: [], stormCount: 0 };
+}
+
+export function toolCallSignature(toolName: string, args: unknown): string {
+  const normalized = `${toolName}\n${normalizeArgs(args)}`;
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
+export function observeToolCallStorm(
+  state: ToolStormState,
+  toolCall: ToolCall,
+  config: ToolStormConfig = readToolStormConfigFromEnv(),
+): ToolStormVerdict {
+  const toolName = toolCall.function?.name || '';
+  const signature = toolCallSignature(toolName, toolCall.function?.arguments || '{}');
+  const recent = state.history.slice(-config.windowSize);
+  const seenBefore = recent.filter((entry) => entry.signature === signature).length;
+  const seen = seenBefore + 1;
+  const storm = !!config.enabled && seen >= config.threshold;
+
+  state.history.push({ signature, toolName });
+  if (state.history.length > config.windowSize) {
+    state.history.splice(0, state.history.length - config.windowSize);
+  }
+  if (storm) state.stormCount += 1;
+
+  return {
+    storm,
+    signature,
+    toolName,
+    seen,
+    stormCount: state.stormCount,
+    maxStormsReached: storm && state.stormCount >= config.maxStorms,
+  };
+}
+
+export function buildToolStormReflection(verdict: ToolStormVerdict): string {
+  return JSON.stringify({
+    ok: false,
+    error: 'tool_call_storm_suppressed',
+    tool: verdict.toolName,
+    repeat_count: verdict.seen,
+    message: 'The same server-side tool was requested repeatedly with identical arguments. Do not call it again unless the arguments change; summarize or answer from the existing tool result instead.',
+  });
+}


### PR DESCRIPTION
## Summary
- add a feature-flagged Brain v2 server-tool storm guard (`BRAIN_V2_STORM_DETECT=1`)
- detect repeated identical `(tool, args)` calls using stable JSON hashing inside a sliding window
- suppress duplicate server-tool execution by returning a tool-role reflection, then emit `tool_storm_limit` after repeated suppressed loops

## Default Behavior
- disabled by default, so production routing/tool behavior is unchanged unless `BRAIN_V2_STORM_DETECT=1` is set

## Validation
- `cd brain-v2-mirror && npm run tsc`
- `cd brain-v2-mirror && npm test -- --reporter=dot __tests__/tool-storm.test.js __tests__/router.test.js`
- `cd brain-v2-mirror && npm test -- --reporter=dot`
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npm run release:gate`
