### PR TITLE
perf(brain-v2): compact historical tool results

### DIFF
--- a/brain-v2-mirror/__tests__/context-compact.test.js
+++ b/brain-v2-mirror/__tests__/context-compact.test.js
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  __testing__,
+  compactToolResults,
+  readToolResultCompactionConfigFromEnv,
+} from '../context-compact.js';
+
+afterEach(() => {
+  delete process.env.BRAIN_V2_TOOL_RESULT_CAP;
+  delete process.env.BRAIN_V2_TOOL_RESULT_KEEP_LATEST;
+});
+
+describe('context compaction', () => {
+  it('defaults to a conservative enabled cap', () => {
+    expect(readToolResultCompactionConfigFromEnv()).toEqual({
+      capChars: 12000,
+      keepLatest: 1,
+    });
+  });
+
+  it('does nothing when cap is disabled', () => {
+    const messages = [{ role: 'tool', content: 'x'.repeat(20) }];
+    expect(compactToolResults(messages, { capChars: 0, keepLatest: 1 })).toBe(messages);
+  });
+
+  it('keeps the latest tool result complete and compacts older large ones', () => {
+    const older = 'a'.repeat(20);
+    const latest = 'b'.repeat(20);
+    const messages = [
+      { role: 'user', content: 'q' },
+      { role: 'tool', tool_call_id: 'old', content: older },
+      { role: 'assistant', content: 'more' },
+      { role: 'tool', tool_call_id: 'latest', content: latest },
+    ];
+
+    const compacted = compactToolResults(messages, { capChars: 5, keepLatest: 1 });
+
+    expect(compacted).not.toBe(messages);
+    expect(compacted[1].content).toContain(__testing__.COMPACTED_MARKER);
+    expect(compacted[1].content).toContain('original_chars=20');
+    expect(compacted[1].content).toContain('aaaaa');
+    expect(compacted[3].content).toBe(latest);
+  });
+
+  it('is idempotent for already compacted tool results', () => {
+    const messages = [
+      { role: 'tool', tool_call_id: 'old', content: 'x'.repeat(20) },
+      { role: 'tool', tool_call_id: 'latest', content: 'short' },
+    ];
+    const once = compactToolResults(messages, { capChars: 5, keepLatest: 1 });
+    const twice = compactToolResults(once, { capChars: 5, keepLatest: 1 });
+
+    expect(twice).toBe(once);
+  });
+
+  it('does not compact non-tool messages', () => {
+    const content = 'a'.repeat(20);
+    const messages = [{ role: 'assistant', content }];
+    expect(compactToolResults(messages, { capChars: 5, keepLatest: 1 })).toBe(messages);
+  });
+
+  it('supports keeping multiple latest tool results', () => {
+    const messages = [
+      { role: 'tool', tool_call_id: '1', content: 'a'.repeat(20) },
+      { role: 'tool', tool_call_id: '2', content: 'b'.repeat(20) },
+      { role: 'tool', tool_call_id: '3', content: 'c'.repeat(20) },
+    ];
+    const compacted = compactToolResults(messages, { capChars: 5, keepLatest: 2 });
+
+    expect(compacted[0].content).toContain(__testing__.COMPACTED_MARKER);
+    expect(compacted[1].content).toBe(messages[1].content);
+    expect(compacted[2].content).toBe(messages[2].content);
+  });
+});

--- a/brain-v2-mirror/__tests__/router.test.js
+++ b/brain-v2-mirror/__tests__/router.test.js
@@ -53,6 +53,8 @@ afterEach(() => {
   delete process.env.BRAIN_V2_STORM_DETECT;
   delete process.env.BRAIN_V2_STORM_THRESHOLD;
   delete process.env.BRAIN_V2_STORM_MAX;
+  delete process.env.BRAIN_V2_TOOL_RESULT_CAP;
+  delete process.env.BRAIN_V2_TOOL_RESULT_KEEP_LATEST;
 });
 
 describe('Router', () => {
@@ -265,6 +267,44 @@ describe('Router', () => {
     ]);
     expect(chunks.filter(c => c.type === 'tool_progress' && c.event === 'end').map(c => c.ok))
       .toEqual([true, false, false, false]);
+  });
+
+  it('compacts older server tool results before subsequent provider rounds', async () => {
+    process.env.BRAIN_V2_TOOL_RESULT_CAP = '8';
+    let adapterRuns = 0;
+    const roundMessages = [];
+    mockState.adapterFn = async function* ({ messages }) {
+      adapterRuns += 1;
+      roundMessages.push(messages);
+      if (adapterRuns <= 3) {
+        yield {
+          type: 'tool_call_delta',
+          delta: [{
+            index: 0,
+            id: `tc-${adapterRuns}`,
+            type: 'function',
+            function: { name: 'unit_convert', arguments: `{"query":"${adapterRuns * 100}公里"}` },
+          }],
+        };
+        yield { type: 'finish', reason: 'tool_calls' };
+        return;
+      }
+      yield { type: 'content', delta: 'done' };
+      yield { type: 'finish', reason: 'stop' };
+    };
+
+    const result = await run({
+      messages: [{ role: 'user', content: '连续换算' }],
+      onChunk: async () => {},
+    });
+
+    expect(result).toMatchObject({ ok: true, iterations: 4 });
+    const fourthRoundToolMessages = roundMessages[3].filter(m => m.role === 'tool');
+    expect(fourthRoundToolMessages).toHaveLength(3);
+    expect(fourthRoundToolMessages[0].content).toContain('[brain-v2:tool-result-compacted]');
+    expect(fourthRoundToolMessages[1].content).toContain('[brain-v2:tool-result-compacted]');
+    expect(fourthRoundToolMessages[2].content).toContain('【单位换算】');
+    expect(fourthRoundToolMessages[2].content).not.toContain('[brain-v2:tool-result-compacted]');
   });
 });
 

--- a/brain-v2-mirror/context-compact.ts
+++ b/brain-v2-mirror/context-compact.ts
@@ -1,0 +1,75 @@
+import type { ChatMessage } from './types.js';
+
+export type ToolResultCompactionConfig = {
+  capChars: number;
+  keepLatest: number;
+};
+
+const COMPACTED_MARKER = '[brain-v2:tool-result-compacted]';
+const DEFAULT_CAP_CHARS = 12_000;
+
+function positiveInt(value: unknown, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : fallback;
+}
+
+export function readToolResultCompactionConfigFromEnv(): ToolResultCompactionConfig {
+  return {
+    capChars: positiveInt(process.env.BRAIN_V2_TOOL_RESULT_CAP, DEFAULT_CAP_CHARS),
+    keepLatest: positiveInt(process.env.BRAIN_V2_TOOL_RESULT_KEEP_LATEST, 1),
+  };
+}
+
+function contentToString(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (content == null) return '';
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return String(content);
+  }
+}
+
+function compactedContent(original: string, capChars: number): string {
+  const head = original.slice(0, capChars);
+  return [
+    COMPACTED_MARKER,
+    `[tool result compacted: original_chars=${original.length}, kept_chars=${head.length}]`,
+    head,
+    '',
+    'Older tool output was truncated to keep the next provider turn responsive. Re-call the tool with refined arguments if exact omitted details are required.',
+  ].join('\n');
+}
+
+export function compactToolResults(
+  messages: ChatMessage[],
+  config: ToolResultCompactionConfig = readToolResultCompactionConfigFromEnv(),
+): ChatMessage[] {
+  if (!Array.isArray(messages) || config.capChars <= 0) return messages;
+
+  const toolIndexes = messages
+    .map((message, index) => ({ message, index }))
+    .filter(({ message }) => message?.role === 'tool')
+    .map(({ index }) => index);
+  const latestToKeep = new Set(toolIndexes.slice(-config.keepLatest));
+  let changed = false;
+
+  const next = messages.map((message, index) => {
+    if (message?.role !== 'tool') return message;
+    if (latestToKeep.has(index)) return message;
+    const text = contentToString(message.content);
+    if (!text || text.includes(COMPACTED_MARKER) || text.length <= config.capChars) return message;
+    changed = true;
+    return {
+      ...message,
+      content: compactedContent(text, config.capChars),
+    };
+  });
+
+  return changed ? next : messages;
+}
+
+export const __testing__ = {
+  COMPACTED_MARKER,
+  contentToString,
+};

--- a/brain-v2-mirror/router.ts
+++ b/brain-v2-mirror/router.ts
@@ -10,6 +10,7 @@ import { getAdapter } from './wire-adapter/index.js';
 import { isServerTool, executeServerTool, mergeWithServerTools } from './tool-exec/index.js';
 import { applySearchContext, createSearchRequestCache, type SearchRequestCache } from './search-context.js';
 import { applyAudioTranscribe, createAudioRequestCache, type AudioRequestCache } from './audio-transcribe.js';
+import { compactToolResults, readToolResultCompactionConfigFromEnv } from './context-compact.js';
 import {
   buildToolStormReflection,
   createToolStormState,
@@ -268,6 +269,7 @@ export async function run({ messages, tools, capabilityRequired, signal, onChunk
   const audioCache = createAudioRequestCache() as AudioRequestCache;
   const toolStormConfig = readToolStormConfigFromEnv();
   const toolStormState = createToolStormState();
+  const toolResultCompactionConfig = readToolResultCompactionConfigFromEnv();
 
   while (iter < maxIter) {
     iter++;
@@ -323,6 +325,7 @@ export async function run({ messages, tools, capabilityRequired, signal, onChunk
           tool_call_id: tc.id || ('tc-' + Math.random().toString(36).slice(2)),
           content: buildToolStormReflection(stormVerdict),
         });
+        workingMessages = compactToolResults(workingMessages, toolResultCompactionConfig);
         if (stormVerdict.maxStormsReached) {
           await onChunk(
             { type: 'error', error: 'tool_storm_limit', tool: stormVerdict.toolName, storms: stormVerdict.stormCount },
@@ -356,6 +359,7 @@ export async function run({ messages, tools, capabilityRequired, signal, onChunk
         tool_call_id: tc.id || ('tc-' + Math.random().toString(36).slice(2)),
         content: typeof toolResult === 'string' ? toolResult : JSON.stringify(toolResult),
       });
+      workingMessages = compactToolResults(workingMessages, toolResultCompactionConfig);
     }
   }
   // 达 MAX_ITERATIONS 上限 → emit 显式 error chunk (不再撒谎成 finish:stop)


### PR DESCRIPTION
## Summary
- compact older Brain v2 server-tool results before subsequent provider turns
- keep the latest tool result complete while replacing older oversized tool output with an idempotent summary envelope
- support `BRAIN_V2_TOOL_RESULT_CAP=0` to disable compaction and `BRAIN_V2_TOOL_RESULT_KEEP_LATEST` to keep more recent tool results intact

## Notes
- `BRAIN_V2_TOOL_RESULT_CAP` is interpreted as an approximate token budget and converted to a conservative character budget internally
- user/assistant content is never compacted; only historical `role: tool` messages are eligible

## Validation
- `cd brain-v2-mirror && npm run tsc`
- `cd brain-v2-mirror && npm test -- --reporter=dot __tests__/context-compact.test.js __tests__/router.test.js`
- `cd brain-v2-mirror && npm test -- --reporter=dot`
- `npm run typecheck`
- `npm run typecheck:runtime`
- `npm run release:gate`
