### PR TITLE
fix(local-model): add MTP upgrade window for legacy 9B

### DIFF
--- a/desktop/llamacpp-profiles.cjs
+++ b/desktop/llamacpp-profiles.cjs
@@ -33,8 +33,13 @@ const LLAMACPP_BASE_PROFILES = Object.freeze({
   // release uses the dedicated MTP repos and measured DGX Spark 36.61 → 60.95 single TPS.
   [DEFAULT_MODEL_ID]: {
     modelId: DEFAULT_MODEL_ID,
+    revision: "2026-05-28-mtp",
     label: "Qwen3.5-9B Q4_K_M imatrix MTP",
     fileName: "Qwen3.5-9B-Q4_K_M-imatrix-mtp.gguf",
+    supersedesFileNames: [
+      "Qwen3.5-9B-Q4_K_M-imatrix.gguf",
+      "Qwen3.5-9B-Q4_K_M.gguf",
+    ],
     expectedSize: 5_780_090_944,
     expectedSha256: "0f292ba0d1058065a6624883a76a2adf00b266d07b9396ed67b155ff522e18d4",
     parallelSegments: 2,
@@ -45,8 +50,12 @@ const LLAMACPP_BASE_PROFILES = Object.freeze({
   // and saved configs keep working while new downloads use the faster MTP file.
   "qwen36-35b-a3b-apex-mtp": {
     modelId: "qwen36-35b-a3b-apex-mtp",
+    revision: "2026-05-28-apex-mtp",
     label: "Qwen3.6-35B-A3B APEX-MTP I-Balanced",
     fileName: "Qwen3.6-35B-A3B-APEX-MTP-I-Balanced.gguf",
+    supersedesFileNames: [
+      "Qwen3.6-35B-A3B-Q4_K_M-imatrix.gguf",
+    ],
     expectedSize: 26_059_443_808,
     expectedSha256: "9bf7d96bb3a9d363e645dd998aee9e9bff8e016a82aec7ff081e0e6cdb53419e",
     parallelSegments: 4,
@@ -127,6 +136,10 @@ function decorateDownloadState(profile, state = {}) {
     modelId: safeIpcText(profile.modelId, 120),
     modelLabel: safeIpcText(profile.label, 160),
     fileName: safeIpcText(profile.fileName, 200),
+    revision: safeIpcText(profile.revision, 120),
+    supersedesFileNames: Array.isArray(profile.supersedesFileNames)
+      ? profile.supersedesFileNames.map((item) => safeIpcText(item, 200)).filter(Boolean)
+      : [],
   };
   if (state.reason != null) payload.reason = safeIpcText(state.reason, 200);
   if (state.sourceAttempt != null) payload.sourceAttempt = safeNonNegativeNumber(state.sourceAttempt);

--- a/desktop/src/react/settings/tabs/providers/ProviderDetail.tsx
+++ b/desktop/src/react/settings/tabs/providers/ProviderDetail.tsx
@@ -23,6 +23,11 @@ function isLocalQwenProviderId(id?: string | null) {
   return !!id && (LOCAL_QWEN_COMPAT_PROVIDER_IDS.has(id) || /^local-qwen/i.test(id));
 }
 
+function isDefaultQwen35MtpFileName(fileName: string) {
+  return /^Qwen3\.5-9B-Q4_K_M-imatrix-mtp\.gguf$/i.test(fileName)
+    || /qwen3\.?5-?9b.*q4_?k_?m.*mtp.*\.gguf$/i.test(fileName);
+}
+
 type LocalActionStatus = {
   kind: 'info' | 'success' | 'error';
   text: string;
@@ -238,6 +243,9 @@ type LocalQwen35Status = {
       endpoint_occupied?: boolean;
       served_model_ids?: string[];
       gguf?: string | null;
+      legacy_gguf?: string | null;
+      needs_model_upgrade?: boolean;
+      expected_file_name?: string;
       llama_server?: string | null;
       homebrew_available?: boolean;
     };
@@ -305,21 +313,25 @@ function LocalQwen35Panel({ onRefresh }: { onRefresh: () => Promise<void> }) {
       || status?.runtime?.endpoint_loading === true
       || status?.runtime?.process_alive === true
   );
-  const hardwareWarnings = [...new Set([
-    ...(endpointForeign
-      ? [`检测到 18099 当前运行的是 ${servedModelIds.join(', ') || '非默认模型端点'}，它不会作为默认 9B 使用；停止后可启动默认 Qwen3.5-9B MTP。`]
-      : []),
-    ...(hardware.warnings || []),
-    ...(hardware.blockers || []),
-  ])];
   const endpointActive = endpointRunning || endpointLoading;
   const canStopLocalModel = endpointActive || endpointForeign;
   const modelPath = typeof observed.gguf === 'string' ? observed.gguf : '';
   const modelFileName = modelPath ? (modelPath.split(/[\\/]/).pop() || modelPath) : '';
-  // 2026-05-25: 默认模型回到 9B MTP,这里必须只认 9B 默认文件。
-  // 4B 仍可从可选模型里手动降级启动,但不能被默认卡误判为 ready。
-  const hasModel = !!observed.gguf
-    && /qwen3\.?5-?9b.*q4_?k_?m.*(?:imatrix|mtp)?/i.test(modelFileName);
+  const legacyModelPath = typeof observed.legacy_gguf === 'string' ? observed.legacy_gguf : '';
+  const legacyModelFileName = legacyModelPath ? (legacyModelPath.split(/[\\/]/).pop() || legacyModelPath) : '';
+  // 默认卡只认当前 9B MTP artifact。旧 9B GGUF 会显示为可升级,不能挡住新版 MTP 下载。
+  const hasModel = !!observed.gguf && isDefaultQwen35MtpFileName(modelFileName);
+  const needsMtpUpgrade = !hasModel && (observed.needs_model_upgrade === true || !!legacyModelPath);
+  const hardwareWarnings = [...new Set([
+    ...(endpointForeign
+      ? [`检测到 18099 当前运行的是 ${servedModelIds.join(', ') || '非默认模型端点'}，它不会作为默认 9B 使用；停止后可启动默认 Qwen3.5-9B MTP。`]
+      : []),
+    ...(needsMtpUpgrade
+      ? [`检测到旧版 Qwen3.5-9B GGUF：${legacyModelFileName || '旧文件'}。默认档已升级为 MTP；点击升级会下载新版 MTP 文件，旧文件不会被删除。`]
+      : []),
+    ...(hardware.warnings || []),
+    ...(hardware.blockers || []),
+  ])];
   const hasRuntime = !endpointForeign && !!observed.llama_server;
   const defaultDownload = llamaState.download;
   const defaultDownloadState = String(defaultDownload.state || '');
@@ -380,9 +392,10 @@ function LocalQwen35Panel({ onRefresh }: { onRefresh: () => Promise<void> }) {
     if (jobRunning) return '正在准备';
     if (endpointLoading) return '正在加载';
     if (endpointRunning) return '已运行';
+    if (needsMtpUpgrade) return '可升级';
     if (hasModel && hasRuntime) return '可启动';
     return '待安装';
-  }, [endpointForeign, endpointLoading, endpointRunning, hasModel, hasRuntime, jobRunning]);
+  }, [endpointForeign, endpointLoading, endpointRunning, hasModel, hasRuntime, jobRunning, needsMtpUpgrade]);
 
   useEffect(() => {
     if (!jobRunning) return undefined;
@@ -397,17 +410,21 @@ function LocalQwen35Panel({ onRefresh }: { onRefresh: () => Promise<void> }) {
     const warning = hardwareWarnings.length ? `\n\n注意：${hardwareWarnings.join(' ')}` : '';
     const setupText = hasModel && hasRuntime
       ? 'Lynn 将启动本地 Qwen3.5-9B MTP 模型服务，并切换为本地模型。'
-      : 'Lynn 将在本机安装或定位 llama.cpp，下载 Qwen3.5-9B Q4_K_M imatrix MTP，并启动本地模型服务。\n\n模型约 5.78GB / 5.38GiB；新版 MTP 在 DGX Spark 单流从 36.61 提升到 60.95 TPS，thinking-on 和工具调用稳定性强于 4B。完成后可离线使用，不需要 API Key，不上传对话。';
+      : needsMtpUpgrade
+        ? 'Lynn 将保留旧版 9B 文件，并下载新版 Qwen3.5-9B MTP；完成后会启动 MTP 端点。\n\n模型约 5.78GB / 5.38GiB；旧文件不会被删除，你可以稍后手动清理。'
+        : 'Lynn 将在本机安装或定位 llama.cpp，下载 Qwen3.5-9B Q4_K_M imatrix MTP，并启动本地模型服务。\n\n模型约 5.78GB / 5.38GiB；新版 MTP 在 DGX Spark 单流从 36.61 提升到 60.95 TPS，thinking-on 和工具调用稳定性强于 4B。完成后可离线使用，不需要 API Key，不上传对话。';
     const ok = window.confirm(`${setupText}${profile}${warning}\n\n继续吗？`);
     if (!ok) return;
     if (platform?.llamacppStartDownload) {
       setSettingUp(true);
-      setActionStatus({
-        kind: 'info',
-        text: hasModel
-          ? '正在启动默认 Qwen3.5-9B；如果模型文件已完整，Lynn 会直接校验并拉起本地端点。'
-          : '正在下载默认 Qwen3.5-9B，进度会留在当前页面；下载完成后会自动启动本地端点。',
-      });
+        setActionStatus({
+          kind: 'info',
+          text: hasModel
+            ? '正在启动默认 Qwen3.5-9B；如果模型文件已完整，Lynn 会直接校验并拉起本地端点。'
+            : needsMtpUpgrade
+              ? '正在升级到默认 Qwen3.5-9B MTP；旧版文件会保留，新版校验完成后自动启动。'
+              : '正在下载默认 Qwen3.5-9B，进度会留在当前页面；下载完成后会自动启动本地端点。',
+        });
       try {
         const res = await platform.llamacppStartDownload({ modelId: 'qwen35-9b-q4km-imatrix' });
         if (!res?.ok) throw new Error(localModelActionErrorText(res?.reason, res?.detail));
@@ -416,7 +433,9 @@ function LocalQwen35Panel({ onRefresh }: { onRefresh: () => Promise<void> }) {
             ? '默认 9B 已在下载/启动队列中。'
             : hasModel
               ? '默认 Qwen3.5-9B 正在启动。'
-              : '默认 Qwen3.5-9B 已开始下载。',
+              : needsMtpUpgrade
+                ? '默认 Qwen3.5-9B MTP 升级已开始。'
+                : '默认 Qwen3.5-9B 已开始下载。',
           'info',
         );
         setActionStatus({
@@ -425,7 +444,9 @@ function LocalQwen35Panel({ onRefresh }: { onRefresh: () => Promise<void> }) {
             ? '默认 9B 已在下载/启动队列中，进度会自动刷新。'
             : hasModel
               ? '启动任务已提交。加载完成后会自动切换为本地模型。'
-              : '默认 9B 下载已启动，校验完成后会自动启动本地端点。',
+              : needsMtpUpgrade
+                ? '新版 MTP 下载已启动，校验完成后会自动启动本地端点。'
+                : '默认 9B 下载已启动，校验完成后会自动启动本地端点。',
         });
         await onRefresh();
         window.setTimeout(loadStatus, 1500);
@@ -676,8 +697,10 @@ function LocalQwen35Panel({ onRefresh }: { onRefresh: () => Promise<void> }) {
       </div>
 
       <div className={styles['pv-local-qwen-facts']}>
-        <span>模型 {hasModel ? '已就绪' : '待下载'}</span>
+        <span>模型 {hasModel ? '已就绪' : needsMtpUpgrade ? '可升级到 MTP' : '待下载'}</span>
         {modelFileName && <span title={modelPath}>模型文件 {modelFileName}</span>}
+        {needsMtpUpgrade && legacyModelFileName && <span title={legacyModelPath}>旧版 9B {legacyModelFileName}</span>}
+        {needsMtpUpgrade && <span>新版 MTP 待下载</span>}
         <span>llama.cpp {hasRuntime ? '已找到' : '待安装'}</span>
         {endpointForeign && <span>当前端点 {servedModelIds.join(', ') || '非默认 9B'}</span>}
         {(endpointActive || endpointForeign) && runtimeStats?.pid && <span>PID {runtimeStats.pid}</span>}
@@ -833,6 +856,7 @@ function LocalQwen35Panel({ onRefresh }: { onRefresh: () => Promise<void> }) {
               <strong>已有 GGUF / 模型目录</strong>
               <span>默认使用 Qwen3.5-9B MTP。4B 仅作为低配降级，thinking-on 可能长思考后无正文；也可以导入已经下载好的 35B 或其他 GGUF。</span>
               {modelPath && <code className={styles['pv-local-qwen-model-path']}>{modelPath}</code>}
+              {needsMtpUpgrade && legacyModelPath && <code className={styles['pv-local-qwen-model-path']}>旧版 9B：{legacyModelPath}</code>}
             </div>
             <div className={styles['pv-local-qwen-advanced-actions']}>
               <button type="button" className={styles['pv-verify-connection-btn']} onClick={openModelFolder}>
@@ -911,6 +935,8 @@ function LocalQwen35Panel({ onRefresh }: { onRefresh: () => Promise<void> }) {
                 ? '已启用，重新检查'
                 : hasModel && hasRuntime
                   ? '启动本地模型'
+                  : needsMtpUpgrade
+                    ? '升级到 9B MTP (5.78 GB)'
                   : !hasModel
                     ? '下载 9B 并启动 (5.78 GB)'
                     : '授权安装并启用'}

--- a/desktop/src/react/settings/tabs/providers/local-qwen-provider.test.ts
+++ b/desktop/src/react/settings/tabs/providers/local-qwen-provider.test.ts
@@ -145,12 +145,34 @@ describe('Local Qwen provider UX guards', () => {
     const downloader = read('desktop/model-downloader.cjs');
     const route = read('server/routes/local-qwen35.ts');
     expect(profiles).toContain('Qwen3.5-9B-Q4_K_M-imatrix-mtp.gguf');
+    expect(profiles).toContain('revision: "2026-05-28-mtp"');
+    expect(profiles).toContain('supersedesFileNames');
+    expect(profiles).toContain('Qwen3.5-9B-Q4_K_M-imatrix.gguf');
     expect(profiles).toContain('0f292ba0d1058065a6624883a76a2adf00b266d07b9396ed67b155ff522e18d4');
     expect(downloader).toContain('Merkyor/Qwen3.5-9B-GGUF-imatrix-MTP');
     expect(downloader).toContain('nerkyor/Qwen3.5-9B-GGUF-imatrix-MTP');
     expect(route).toContain('Qwen3.5-9B Q4_K_M imatrix MTP');
     expect(route).toContain('Qwen3.5-4B Q4_K_M imatrix (低配降级)');
     expect(route).not.toContain('Qwen3.5-4B Q4_K_M (unsloth)');
+  });
+
+  it('detects older 9B GGUF files as upgrade candidates instead of default-ready MTP', () => {
+    const panel = read('desktop/src/react/settings/tabs/providers/ProviderDetail.tsx');
+    const bootstrap = read('scripts/local_qwen35_9b_client_bootstrap.py');
+    const setup = read('scripts/local_qwen35_9b_setup.sh');
+    expect(panel).toContain('isDefaultQwen35MtpFileName');
+    expect(panel).toContain('needs_model_upgrade');
+    expect(panel).toContain('升级到 9B MTP (5.78 GB)');
+    expect(panel).toContain('旧版 9B');
+    expect(panel).toContain('新版 MTP 待下载');
+    expect(bootstrap).toContain('DEFAULT_MODEL_FILE_NAME = "Qwen3.5-9B-Q4_K_M-imatrix-mtp.gguf"');
+    expect(bootstrap).toContain('LEGACY_MODEL_FILE_NAMES');
+    expect(bootstrap).toContain('"legacy_gguf"');
+    expect(bootstrap).toContain('"needs_model_upgrade"');
+    expect(bootstrap).toContain('Upgrade Qwen3.5-9B to Q4_K_M imatrix MTP GGUF');
+    expect(setup).toContain('find_legacy_gguf');
+    expect(setup).toContain('legacy 9B GGUF found but default requires MTP');
+    expect(setup).toContain('is_default_mtp_gguf_path "$candidate" || continue');
   });
 
   it('keeps local model progress out of model-visible thinking', () => {

--- a/scripts/local_qwen35_9b_client_bootstrap.py
+++ b/scripts/local_qwen35_9b_client_bootstrap.py
@@ -37,6 +37,11 @@ DEFAULT_PROVIDER_ID = "local-qwen35-9b-q4km-imatrix"
 DEFAULT_MODEL_ID = "qwen35-9b-q4km-imatrix"
 DEFAULT_ARTIFACT_ID = "qwen35-9b-q4km-imatrix-gguf"
 DEFAULT_MODEL_FAMILY = "Qwen3.5-9B"
+DEFAULT_MODEL_FILE_NAME = "Qwen3.5-9B-Q4_K_M-imatrix-mtp.gguf"
+LEGACY_MODEL_FILE_NAMES = {
+    "qwen3.5-9b-q4_k_m-imatrix.gguf",
+    "qwen3.5-9b-q4_k_m.gguf",
+}
 DEFAULT_MODEL_ROOT = Path.home() / "Models" / "Lynn" / "Qwen3.5-9B"
 DEFAULT_PROVIDER = Path.home() / ".lynn-engine" / "providers" / f"{DEFAULT_MODEL_ID}-gguf.json"
 DEFAULT_PID_FILE = Path.home() / ".lynn-engine" / "run" / f"{DEFAULT_MODEL_ID}.pid"
@@ -121,19 +126,19 @@ def _wait_ready(base_url: str, *, timeout_sec: float = 180.0) -> bool:
     return _health(base_url) and _models_ready(base_url)
 
 
-def _find_gguf(model_root: Path, variant: str) -> Path | None:
-    """Search for the DEFAULT MODEL (Qwen3.5-9B Q4_K_M imatrix MTP) on disk."""
-    def is_complete_candidate(path: Path) -> bool:
-        # ModelScope keeps in-flight downloads under a hidden ._____temp folder.
-        # Never treat those partial files as usable GGUFs. Do not reject
-        # ~/.lynn/models itself: that is Lynn's canonical in-app model cache.
-        parts = path.parts
-        if any(part.startswith("._____temp") or part in {".cache", ".tmp"} for part in parts):
-            return False
-        if path.name.endswith((".part", ".tmp", ".download")):
-            return False
-        return True
+def _is_complete_gguf_candidate(path: Path) -> bool:
+    # ModelScope keeps in-flight downloads under a hidden ._____temp folder.
+    # Never treat those partial files as usable GGUFs. Do not reject
+    # ~/.lynn/models itself: that is Lynn's canonical in-app model cache.
+    parts = path.parts
+    if any(part.startswith("._____temp") or part in {".cache", ".tmp"} for part in parts):
+        return False
+    if path.name.endswith((".part", ".tmp", ".download")):
+        return False
+    return True
 
+
+def _iter_gguf_candidates(model_root: Path) -> list[Path]:
     # Also probe the canonical .lynn/models target used by Lynn's in-app
     # downloader (model-downloader.cjs DEFAULT target). Without this, a user
     # who completed the in-app install gets a "no model found" false negative.
@@ -145,20 +150,60 @@ def _find_gguf(model_root: Path, variant: str) -> Path | None:
         Path.home() / "models",
         Path.home() / "Downloads",
     ]
+    candidates: list[Path] = []
+    seen: set[str] = set()
     for root in roots:
         if not root.exists():
             continue
-        candidates = sorted(p for p in root.rglob("*.gguf") if is_complete_candidate(p))
-        # Default model = Qwen3.5-9B Q4_K_M imatrix MTP.
-        preferred = [
-            p for p in candidates
-            if "qwen3.5" in p.name.lower()
-            and "9b" in p.name.lower()
-            and "q4_k_m" in p.name.lower()
-        ]
-        if preferred:
-            return preferred[0]
-    return None
+        for path in sorted(p for p in root.rglob("*.gguf") if _is_complete_gguf_candidate(p)):
+            key = str(path.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append(path)
+    return candidates
+
+
+def _is_default_mtp_gguf(path: Path) -> bool:
+    name = path.name.lower()
+    if name == DEFAULT_MODEL_FILE_NAME.lower():
+        return True
+    return (
+        name.endswith(".gguf")
+        and "qwen3.5" in name
+        and "9b" in name
+        and "q4" in name
+        and "k" in name
+        and "m" in name
+        and "mtp" in name
+    )
+
+
+def _is_legacy_9b_gguf(path: Path) -> bool:
+    name = path.name.lower()
+    if name in LEGACY_MODEL_FILE_NAMES:
+        return True
+    return (
+        name.endswith(".gguf")
+        and "qwen3.5" in name
+        and "9b" in name
+        and "q4" in name
+        and "k" in name
+        and "m" in name
+        and "mtp" not in name
+    )
+
+
+def _find_gguf(model_root: Path, variant: str) -> Path | None:
+    """Search for the current DEFAULT MODEL (Qwen3.5-9B Q4_K_M imatrix MTP)."""
+    candidates = [path for path in _iter_gguf_candidates(model_root) if _is_default_mtp_gguf(path)]
+    return candidates[0] if candidates else None
+
+
+def _find_legacy_gguf(model_root: Path) -> Path | None:
+    """Find older 9B Q4_K_M files for upgrade messaging only; never use as default."""
+    candidates = [path for path in _iter_gguf_candidates(model_root) if _is_legacy_9b_gguf(path)]
+    return candidates[0] if candidates else None
 
 
 def _run_capture(cmd: list[str], timeout: float = 5.0) -> str:
@@ -412,6 +457,8 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     base_url = f"http://{host}:{port}/v1"
     provider = _read_provider(provider_path)
     gguf = _find_gguf(model_root, args.variant)
+    legacy_gguf = None if gguf else _find_legacy_gguf(model_root)
+    needs_model_upgrade = gguf is None and legacy_gguf is not None
     llama_server = _which("llama-server") or _which("llama.cpp-server")
     has_brew = _which("brew") is not None
     running = _probe_port(host, port) and _health(base_url) and _models_ready(base_url)
@@ -428,10 +475,12 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     if gguf is None:
         actions.append({
             "id": "download_model",
-            "label": "Download Qwen3.5-9B Q4_K_M imatrix MTP GGUF",
+            "label": "Upgrade Qwen3.5-9B to Q4_K_M imatrix MTP GGUF" if needs_model_upgrade else "Download Qwen3.5-9B Q4_K_M imatrix MTP GGUF",
             "requires_user_authorization": True,
             "approx_download_gib": 5.38,
             "artifact_id": DEFAULT_ARTIFACT_ID,
+            "expected_file_name": DEFAULT_MODEL_FILE_NAME,
+            "replaces": str(legacy_gguf) if legacy_gguf else None,
         })
     if provider is None:
         actions.append({
@@ -463,6 +512,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             "machine": platform.machine(),
             "llama_server": llama_server,
             "gguf": str(gguf) if gguf else None,
+            "legacy_gguf": str(legacy_gguf) if legacy_gguf else None,
+            "needs_model_upgrade": needs_model_upgrade,
+            "expected_file_name": DEFAULT_MODEL_FILE_NAME,
             "provider_config_exists": provider is not None,
             "endpoint_running": running,
             "homebrew_available": has_brew,

--- a/scripts/local_qwen35_9b_setup.sh
+++ b/scripts/local_qwen35_9b_setup.sh
@@ -221,8 +221,35 @@ find_llama_server() {
   return 1
 }
 
+is_complete_gguf_candidate() {
+  local path="$1"
+  [[ -s "$path" ]] || return 1
+  case "$path" in
+    *"/._____temp/"*|*"/.cache/"*|*"/.tmp/"*|*.part|*.tmp|*.download) return 1 ;;
+  esac
+  return 0
+}
+
+is_default_mtp_gguf_path() {
+  local base lower expected
+  base="${1##*/}"
+  lower="${base,,}"
+  expected="${Q4KM_FILE,,}"
+  [[ "$lower" == "$expected" ]] && return 0
+  [[ "$lower" == *qwen3.5*9b*q4*k*m*mtp*.gguf ]] && return 0
+  return 1
+}
+
+is_legacy_9b_gguf_path() {
+  local base lower
+  base="${1##*/}"
+  lower="${base,,}"
+  [[ "$lower" == *qwen3.5*9b*q4*k*m*.gguf && "$lower" != *mtp* ]] && return 0
+  return 1
+}
+
 find_existing_gguf() {
-  if [[ -s "$Q4KM_PATH" ]]; then
+  if is_complete_gguf_candidate "$Q4KM_PATH" && is_default_mtp_gguf_path "$Q4KM_PATH"; then
     printf '%s\n' "$Q4KM_PATH"
     return 0
   fi
@@ -230,8 +257,27 @@ find_existing_gguf() {
   for root in "$HOME/.lynn/models" "$Q4KM_DIR" "$MODEL_ROOT" "$HOME/Models" "$HOME/models" "$HOME/Downloads" "$ROOT/models"; do
     [[ -d "$root" ]] || continue
     while IFS= read -r candidate; do
-      [[ "$candidate" == *"/."* ]] && continue
-      [[ -s "$candidate" ]] || continue
+      is_complete_gguf_candidate "$candidate" || continue
+      is_default_mtp_gguf_path "$candidate" || continue
+      printf '%s\n' "$candidate"
+      return 0
+    done < <(find "$root" -maxdepth 5 -type f \( \
+      -iname '*Qwen3.5*9B*Q4*K*M*.gguf' -o \
+      -iname '*qwen3.5*9b*q4*k*m*.gguf' -o \
+      -iname '*Qwen3.5*9B*Q4_K_M*.gguf' -o \
+      -iname '*qwen3.5*9b*q4_k_m*.gguf' \
+    \) 2>/dev/null | sort)
+  done
+  return 1
+}
+
+find_legacy_gguf() {
+  local root candidate
+  for root in "$HOME/.lynn/models" "$Q4KM_DIR" "$MODEL_ROOT" "$HOME/Models" "$HOME/models" "$HOME/Downloads" "$ROOT/models"; do
+    [[ -d "$root" ]] || continue
+    while IFS= read -r candidate; do
+      is_complete_gguf_candidate "$candidate" || continue
+      is_legacy_9b_gguf_path "$candidate" || continue
       printf '%s\n' "$candidate"
       return 0
     done < <(find "$root" -maxdepth 5 -type f \( \
@@ -358,6 +404,10 @@ EOF
 }
 
 resolved_gguf="$(find_existing_gguf || true)"
+resolved_legacy_gguf=""
+if [[ -z "$resolved_gguf" ]]; then
+  resolved_legacy_gguf="$(find_legacy_gguf || true)"
+fi
 resolved_llama="$(find_llama_server || true)"
 if [[ -z "$resolved_llama" && "$INSTALL_RUNTIME" == "1" && "$DRY_RUN" != "1" ]]; then
   install_llama_cpp_runtime
@@ -370,6 +420,7 @@ cat <<EOF
 [qwen35-setup] source=$SOURCE download=$DOWNLOAD smoke=$SMOKE serve=$SERVE install_runtime=$INSTALL_RUNTIME
 [qwen35-setup] target_gguf=$Q4KM_PATH
 [qwen35-setup] found_gguf=${resolved_gguf:-<missing>}
+[qwen35-setup] legacy_gguf=${resolved_legacy_gguf:-<none>}
 [qwen35-setup] llama_server=${resolved_llama:-<missing>}
 EOF
 
@@ -379,6 +430,9 @@ if [[ "$DRY_RUN" == "1" ]]; then
 fi
 
 if [[ -z "$resolved_gguf" ]]; then
+  if [[ -n "$resolved_legacy_gguf" ]]; then
+    echo "[qwen35-setup] legacy 9B GGUF found but default requires MTP; will download/upgrade to $Q4KM_FILE"
+  fi
   if [[ "$DOWNLOAD" == "1" ]]; then
     if ! download_model; then
       cat >&2 <<EOF


### PR DESCRIPTION
## Summary
- add explicit local model profile revisions and superseded GGUF metadata for 9B/35B MTP releases
- make bootstrap/setup treat old 9B GGUF files as upgrade candidates instead of default-ready models
- surface legacy 9B -> MTP upgrade state in the Providers UI

## Verification
- python3 -m py_compile scripts/local_qwen35_9b_client_bootstrap.py
- bash -n scripts/local_qwen35_9b_setup.sh
- npm test -- --run desktop/src/react/settings/tabs/providers/local-qwen-provider.test.ts
- npm run typecheck
- npm run typecheck:runtime
- npm run release:gate
- HEAD checks: ModelScope/HF 9B + 35B repo pages returned HTTP 200

No local model artifacts were downloaded.