### PR TITLE
docs(cli): add Lynn CLI Agent Quick Contract + ops contract to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,48 @@ Lynn 现在不只是桌面端 Agent。配套的模型、量化和自研推理引
 
 > 说明:27B Lynn-native NVFP4 是给 Lynn Engine 的内部/垂直 runtime artifact;通用用户仍建议从 V4 / V Flash 的 BF16、NVFP4 v8-RTN 或 Q4_K_M 版本开始。
 
+---
+
+## ⚡ Lynn CLI · Agent Quick Contract
+
+`Lynn` 是 Lynn 的 CLI / worker-runner（v0.80 alpha）。定位：**Codex / Claude 指挥，Lynn worker 执行**。
+
+```bash
+# 安装（npm 包未发布，从 Lynn 镜像 tarball 装；--force 替换旧 shim）
+npm install -g --force https://download.merkyorlynn.com/downloads/cli/lynn-cli-latest.tgz
+
+Lynn doctor --offline             # 自检
+Lynn -p "总结这个 repo" --json     # 单次任务，JSONL 输出
+Lynn code "review the diff"        # 代码 agent 模式
+Lynn chat                          # 交互 REPL
+```
+
+**Fleet worker（GUI Fleet 与各家 coding CLI 的统一适配器）：**
+
+```bash
+Lynn worker run --brief task.md --worktree . --jsonl                 # step-3.7 (via Brain)
+Lynn worker run --brief task.md --worktree . --agent codex-cli --jsonl
+Lynn worker run --brief task.md --worktree . --agent claude-code --jsonl
+Lynn worker run --brief task.md --worktree . --agent qwen-cli --jsonl
+```
+
+一个 `--agent` 把任务派给 codex / claude-code / qwen / kimi / opencode，统一吐 Fleet JSONL。
+**安全边界守在 Lynn 侧**（ownership / forbidden-glob / diff 校验），不靠外部 worker 的 `--yolo`。
+
+**Fleet JSONL 事件（逐行，每条带 workerId + agent）：**
+
+```jsonl
+{"type":"assistant.delta","workerId":"w1","agent":"step-3.7","text":"Here is the fix..."}
+{"type":"tool.finished","workerId":"w1","agent":"step-3.7","name":"write_file","ok":true}
+{"type":"shell.finished","workerId":"w1","agent":"step-3.7","command":"npm test","exitCode":0,"ok":true}
+{"type":"gate.finished","workerId":"w1","agent":"step-3.7","ok":true}
+```
+
+成功信号 = `gate.finished.ok`；硬失败 = `worker.violation` 或 `worker.error{recoverable:false}`。
+
+完整规范（BYOK 配置 / agent 适配表 / 全事件 schema / code tools）：
+→ [`docs/ops/lynn-cli-agent-contract.md`](docs/ops/lynn-cli-agent-contract.md)
+
 ## 🆕 近期更新
 
 <details>

--- a/docs/ops/lynn-cli-agent-contract.md
+++ b/docs/ops/lynn-cli-agent-contract.md
@@ -1,0 +1,166 @@
+# Lynn CLI · Agent Quick Contract
+
+> Machine-readable invocation spec for orchestrators and Fleet workers.
+> Command is `Lynn` (uppercase primary, `lynn` lowercase alias).
+> v0.80 alpha. Verified against `cli/` on branch `claude/v080-cli-gaps`.
+
+---
+
+## Install
+
+```bash
+# Lynn mirror tarball (npm registry package not yet published)
+npm install -g --force https://download.merkyorlynn.com/downloads/cli/lynn-cli-latest.tgz
+
+# Slow deps in mainland China:
+npm install -g --force https://download.merkyorlynn.com/downloads/cli/lynn-cli-latest.tgz \
+  --registry=https://registry.npmmirror.com
+```
+
+`--force` lets npm replace an older `Lynn`/`lynn` shim. Requires Node ≥ 20.
+
+**Routing:** GUI running → local Lynn server / Brain chain (default MiMo, full cascade + Fleet).
+GUI not running → user-owned BYOK endpoint (`Lynn providers set`).
+
+---
+
+## Non-Interactive Invocation
+
+```bash
+Lynn -p "PROMPT" --json                          # one-shot, JSONL out, exits
+Lynn exec "TASK" --reasoning auto --json         # exec mode
+Lynn code "TASK"                                 # code agent (read/write/bash/grep in cwd)
+echo "..." | Lynn -p "PROMPT" --json             # piped stdin
+Lynn - < FILE                                    # file as stdin
+```
+
+`-p` / `--json` forces non-TTY JSONL mode (also auto-detected when stdout is a pipe).
+Brain or a configured BYOK provider must be reachable; `Lynn doctor --offline` checks setup.
+
+---
+
+## BYOK Setup (CLI-only, GUI not running)
+
+```bash
+Lynn providers set --preset stepfun --api-key <key>   # step-3.7
+Lynn providers set --preset mimo    --api-key <key>   # MiMo
+Lynn providers presets                                # list presets
+# manual:
+Lynn providers set --base-url https://api.x.com/v1 --api-key <key> --model <id>
+```
+
+Stored at `~/.lynn/providers/cli.json`, key redacted in terminal output.
+
+---
+
+## Worker Mode (the Fleet adapter)
+
+`Lynn worker run` is the stable bridge between GUI Fleet and coding CLIs. Reads a
+task brief (markdown), runs in a worktree, emits Fleet JSONL.
+
+```bash
+# step-3.7 worker (via Brain)
+Lynn worker run --brief task.md --worktree . --jsonl
+
+# wrap an external agent CLI (Lynn = unified adapter)
+Lynn worker run --brief task.md --worktree . --agent codex-cli    --jsonl
+Lynn worker run --brief task.md --worktree . --agent claude-code  --jsonl
+Lynn worker run --brief task.md --worktree . --agent qwen-cli     --jsonl
+Lynn worker run --brief task.md --worktree . --agent kimi-cli     --jsonl
+Lynn worker run --brief task.md --worktree . --agent opencode     --jsonl
+
+# dry run (no model)
+Lynn worker run --brief task.md --worktree . --mock --jsonl
+
+# custom adapter
+Lynn worker run --brief task.md --worktree . \
+  --agent custom --agent-command "node ./scripts/my-worker.mjs" --jsonl
+```
+
+**Built-in external agent commands** (Lynn prepends guardrails, runs non-interactive):
+
+| `--agent` | underlying command |
+|---|---|
+| `codex-cli` | `codex exec --cd <wt> --json --dangerously-bypass-approvals-and-sandbox <brief>` |
+| `claude-code` | `claude -p <brief> --add-dir <wt> --output-format stream-json --include-partial-messages --dangerously-skip-permissions` |
+| `qwen-cli` | `qwen -p <brief> --add-dir <wt> --output-format stream-json --approval-mode yolo --yolo` |
+| `kimi-cli` | `kimi --work-dir <wt> --print --output-format stream-json --yolo --afk -p <brief>` |
+| `opencode` | `opencode run --format json --cwd <wt> <brief>` |
+
+External workers receive env: `LYNN_WORKER_ID`, `LYNN_WORKER_AGENT`, `LYNN_NO_MODEL_DOWNLOADS=1`.
+Lines already in Fleet JSONL are forwarded; plain stdout/stderr wrapped as `worker.progress`.
+
+**Safety lives on the Lynn side, not the worker flags.** Fleet validates claimed
+ownership, forbidden globs, and the resulting diff. The `--yolo` /
+`--dangerously-*` flags on wrapped CLIs only stop them stalling on interactive
+approval — they do not relax Lynn's boundary checks.
+
+---
+
+## Fleet JSONL Event Stream
+
+Newline-delimited JSON. Every event carries `workerId` and `agent`.
+
+```jsonl
+{"type":"reasoning.delta","workerId":"w1","agent":"step-3.7","text":"...","hidden":true}
+{"type":"assistant.delta","workerId":"w1","agent":"step-3.7","text":"Here is the fix..."}
+{"type":"tool.started","workerId":"w1","agent":"step-3.7","name":"write_file"}
+{"type":"tool.finished","workerId":"w1","agent":"step-3.7","name":"write_file","ok":true}
+{"type":"shell.started","workerId":"w1","agent":"step-3.7","command":"npm test"}
+{"type":"shell.output","workerId":"w1","agent":"step-3.7","text":"..."}
+{"type":"shell.finished","workerId":"w1","agent":"step-3.7","command":"npm test","exitCode":0,"ok":true}
+{"type":"test.started","workerId":"w1","agent":"step-3.7","command":"npm test"}
+{"type":"test.finished","workerId":"w1","agent":"step-3.7","ok":true,"summary":"...","ms":4210}
+{"type":"git.diff","workerId":"w1","agent":"step-3.7","...":"..."}
+{"type":"gate.finished","workerId":"w1","agent":"step-3.7","ok":true}
+{"type":"worker.progress","workerId":"w1","agent":"codex-cli","text":"raw stdout line"}
+{"type":"worker.violation","workerId":"w1","agent":"step-3.7","...":"ownership/glob breach"}
+{"type":"worker.error","workerId":"w1","agent":"step-3.7","code":"worker_exit_nonzero","message":"...","recoverable":true}
+```
+
+**Event types:**
+
+| type | meaning | key fields |
+|---|---|---|
+| `reasoning.delta` | thinking trace (hidden) | `text`, `hidden:true` |
+| `assistant.delta` | answer streaming | `text` |
+| `tool.started` / `tool.finished` | model tool call | `name`, `ok` |
+| `shell.started` / `shell.output` / `shell.finished` | shell command | `command`, `exitCode`, `ok` |
+| `test.started` / `test.finished` | test run | `command`, `ok`, `summary`, `ms` |
+| `git.diff` | resulting diff | diff payload |
+| `gate.finished` | Lynn-side validation gate | `ok` |
+| `worker.progress` | wrapped external agent raw output | `text` |
+| `worker.violation` | ownership / forbidden-glob breach | breach detail |
+| `worker.error` | worker failure | `code`, `message`, `recoverable` |
+
+**Orchestrator parse pattern:**
+- Answer = concat `assistant.delta.text`
+- Success signal = `gate.finished.ok === true` (or final `shell/test.finished.ok`)
+- Hard fail = any `worker.violation`, or `worker.error` with `recoverable:false`
+- Non-zero worker exit → `worker.error` `code:"worker_exit_nonzero"`
+
+---
+
+## Code Tools (direct, outside worker mode)
+
+```bash
+Lynn code --tool bash --command "npm test" --approval yolo --timeout-ms 300000 --json
+Lynn code --tool write_file ... --approval yolo
+```
+
+`bash` and `write_file` require `--approval yolo`. Bash defaults to 120s timeout,
+stdout/stderr capped to keep stuck commands from blocking Fleet workers.
+
+---
+
+## Health Check
+
+```bash
+Lynn version
+Lynn doctor --offline                    # local setup check, no network
+Lynn -p "ping" --json                    # end-to-end smoke
+```
+
+---
+
+*Contract v0.2 · Lynn CLI v0.80 alpha · verified against cli/ source 2026-05-31*


### PR DESCRIPTION
## 为什么

`https://github.com/MerkyorLynn/Lynn/blob/main/docs/ops/lynn-cli-agent-contract.md` 当前 404 —— 文件只在工作分支上，从未进 main。本 PR 把这份 CLI 智能体调用规范以**最小、纯文档**的方式补到 main，让已发布（知乎/README）的链接生效。

## 改动

- **新增** `docs/ops/lynn-cli-agent-contract.md`（v0.2，对照 `cli/` 真实源码核验：`Lynn` 命令、tarball 安装、`worker run --agent` 适配表、真实 Fleet JSONL 事件 schema、code tools）
- **README** 在「模型与引擎路线」与「近期更新」之间插入 `⚡ Lynn CLI · Agent Quick Contract` 段，相对链接指向上面的文件

## 范围

纯文档，2 个文件。**不含**当前工作分支上的 TTS / MiMo / web-search / eval 等 WIP —— 那些另行 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)