### PR TITLE
fix(cli): default standalone installs to hosted brain

### DIFF
--- a/cli/src/brain-client.ts
+++ b/cli/src/brain-client.ts
@@ -3,6 +3,7 @@ import type { ChatContentPart } from "./media.js";
 import type { CliProviderProfile } from "./provider-profile.js";
 import { t } from "./i18n.js";
 import { signedBrainHeaders } from "./brain-auth.js";
+import { brainEndpointUrl } from "./brain-url.js";
 
 export interface BrainChatRequest {
   brainUrl: string;
@@ -82,7 +83,7 @@ export async function checkBrainReachable(brainUrl: string, timeoutMs = 350): Pr
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(new URL("/health", brainUrl), {
+    const response = await fetch(brainEndpointUrl(brainUrl, "/health"), {
       method: "GET",
       signal: controller.signal,
     });
@@ -262,7 +263,7 @@ async function* streamBrainOnlyChat(request: BrainChatRequest): AsyncGenerator<B
   const abort = new AbortController();
   const timer = setTimeout(() => abort.abort(), brainRequestTimeoutMs(!!request.fallbackProvider));
   try {
-    response = await fetch(new URL("/v1/chat/completions", request.brainUrl), {
+    response = await fetch(brainEndpointUrl(request.brainUrl, "/v1/chat/completions"), {
       method: "POST",
       headers: { "content-type": "application/json", ...signedBrainHeaders({ pathname: "/v1/chat/completions" }) },
       body: JSON.stringify(body),

--- a/cli/src/brain-status.ts
+++ b/cli/src/brain-status.ts
@@ -1,4 +1,5 @@
 import { modelDisplayName } from "./provider-presets.js";
+import { brainEndpointUrl } from "./brain-url.js";
 
 export interface BrainProviderStatusEntry {
   id: string;
@@ -31,7 +32,7 @@ export async function fetchBrainProviderStatus(brainUrl: string, timeoutMs = 150
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
-    const res = await fetch(new URL("/v1/providers/status", brainUrl), { signal: ctrl.signal });
+    const res = await fetch(brainEndpointUrl(brainUrl, "/v1/providers/status"), { signal: ctrl.signal });
     if (!res.ok) return null;
     const parsed = await res.json() as Partial<BrainProviderStatus>;
     if (parsed?.ok !== true || !Array.isArray(parsed.route) || !Array.isArray(parsed.providers)) return null;

--- a/cli/src/brain-url.ts
+++ b/cli/src/brain-url.ts
@@ -1,0 +1,42 @@
+import { getStringFlag, type ParsedArgs } from "./args.js";
+
+export const LOCAL_BRAIN_URL = "http://127.0.0.1:8790";
+export const HOSTED_BRAIN_URL = "https://api.merkyorlynn.com/api/v2";
+
+export function configuredBrainUrl(args?: ParsedArgs): string | null {
+  return getStringFlag(args?.flags || {}, "brain-url") || process.env.LYNN_BRAIN_URL || null;
+}
+
+export function defaultBrainUrl(): string {
+  return process.env.LYNN_CLI_DISABLE_HOSTED_BRAIN === "1" ? LOCAL_BRAIN_URL : HOSTED_BRAIN_URL;
+}
+
+export async function resolveDefaultBrainUrl(args?: ParsedArgs, timeoutMs = 500): Promise<string> {
+  const explicit = configuredBrainUrl(args);
+  if (explicit) return explicit;
+  if (process.env.LYNN_CLI_DISABLE_HOSTED_BRAIN === "1") return LOCAL_BRAIN_URL;
+  if (await canReachBrain(HOSTED_BRAIN_URL, timeoutMs)) return HOSTED_BRAIN_URL;
+  if (await canReachBrain(LOCAL_BRAIN_URL, timeoutMs)) return LOCAL_BRAIN_URL;
+  return HOSTED_BRAIN_URL;
+}
+
+export function brainEndpointUrl(brainUrl: string, endpointPath: string): URL {
+  const base = new URL(brainUrl.endsWith("/") ? brainUrl : `${brainUrl}/`);
+  const basePath = base.pathname.replace(/\/+$/, "");
+  const cleanEndpoint = endpointPath.replace(/^\/+/, "");
+  base.pathname = `${basePath}/${cleanEndpoint}`.replace(/\/{2,}/g, "/");
+  return base;
+}
+
+async function canReachBrain(brainUrl: string, timeoutMs: number): Promise<boolean> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(brainEndpointUrl(brainUrl, "/health"), { signal: ctrl.signal });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -21,36 +21,39 @@ import { readVersionInfo } from "./version.js";
 import { maybePromptForCliUpdate } from "./self-update.js";
 import type { ProvidersInfo } from "./commands/providers.js";
 import { t } from "./i18n.js";
+import { resolveDefaultBrainUrl } from "./brain-url.js";
 
 async function main(argv = process.argv.slice(2)): Promise<number> {
   installPipeErrorHandler();
 
   if (argv.length === 0) {
     const providerInfo = await resolveProvidersInfo({ command: "providers", positionals: [], flags: {} }, 500);
-    const brainReachable = await checkBrainReachable(providerInfo.brainUrl, 300);
+    const brainUrl = await resolveDefaultBrainUrl({ command: "chat", positionals: [], flags: {} }, 500);
+    const brainReachable = await checkBrainReachable(brainUrl, 500);
+    const startupInfo: ProvidersInfo = { ...providerInfo, brainUrl };
     if (process.stdin.isTTY && process.stdout.isTTY) {
       await maybePromptForCliUpdate({ command: "chat", positionals: [], flags: { ink: true } }, readVersionInfo());
       if (process.env.LYNN_CLI_LEGACY_TUI !== "1") {
-        return runChat({ command: "chat", positionals: [], flags: { ink: true } }, { intro: false, brainReachable });
+        return runChat({ command: "chat", positionals: [], flags: { ink: true, "brain-url": brainUrl } }, { intro: false, brainReachable });
       }
       process.stdout.write(`${renderStartupBanner({
-        brainUrl: providerInfo.brainUrl,
+        brainUrl,
         brainStatus: brainReachable ? "online" : "offline",
-        modelLabel: startupModelLabel(providerInfo, brainReachable),
-        byokLabel: providerInfo.cliProvider?.configured ? t("startup.byok.cliFallback") : undefined,
+        modelLabel: startupModelLabel(startupInfo, brainReachable),
+        byokLabel: startupInfo.cliProvider?.configured ? t("startup.byok.cliFallback") : undefined,
         showTips: brainReachable,
       })}\n`);
       // Always enter the interactive REPL — even when the Brain is offline.
       // runChat prints the offline hint, then each message returns an actionable
       // recovery line (configure BYOK / start the client) instead of dropping the
       // user back to the shell (which made `Lynn` look like it "doesn't work").
-      return runChat({ command: "chat", positionals: [], flags: {} }, { intro: false, brainReachable });
+      return runChat({ command: "chat", positionals: [], flags: { "brain-url": brainUrl } }, { intro: false, brainReachable });
     }
     process.stdout.write(`${renderStartupBanner({
-      brainUrl: providerInfo.brainUrl,
+      brainUrl,
       brainStatus: brainReachable ? "online" : "offline",
-      modelLabel: startupModelLabel(providerInfo, brainReachable),
-      byokLabel: providerInfo.cliProvider?.configured ? t("startup.byok.cliFallback") : undefined,
+      modelLabel: startupModelLabel(startupInfo, brainReachable),
+      byokLabel: startupInfo.cliProvider?.configured ? t("startup.byok.cliFallback") : undefined,
       showTips: brainReachable,
     })}\n`);
     return 0;

--- a/cli/src/commands/chat.ts
+++ b/cli/src/commands/chat.ts
@@ -22,6 +22,7 @@ import { buildImagesContentParts } from "../media.js";
 import { parseImagePromptCommand, summarizeImageRefs } from "../pasted-context.js";
 import { buildMemoryContextFrameSync, handleMemorySlashCommand } from "../session/memory.js";
 import { resolveDataDir } from "../session/store.js";
+import { resolveDefaultBrainUrl } from "../brain-url.js";
 
 export const CHAT_SLASH_COMMANDS = [
   "/exit",
@@ -72,7 +73,7 @@ export async function runChat(args: ParsedArgs, options: { intro?: boolean; brai
     return runInkChat(args);
   }
   const mockBrain = hasFlag(args.flags, "mock-brain", "mock");
-  const brainUrl = getStringFlag(args.flags, "brain-url") || process.env.LYNN_BRAIN_URL || "http://127.0.0.1:8790";
+  const brainUrl = await resolveDefaultBrainUrl(args);
   const chatCwd = getStringFlag(args.flags, "cwd") || process.cwd();
   let reasoning = parseReasoningOptions(args);
   const mode = await resolveChatMode(args);

--- a/cli/src/commands/code.ts
+++ b/cli/src/commands/code.ts
@@ -35,6 +35,7 @@ import { buildCodeContextMessages, computeCodeContextLayerDiagnostics } from "..
 import { renderToolLedger, toolLedgerEntry, type ToolLedgerEntry } from "../tool-ledger.js";
 import { prepareCodeTaskInput } from "../code-input.js";
 import type { RuntimeInstructionFrame } from "../../../shared/runtime-instruction-frames.js";
+import { resolveDefaultBrainUrl } from "../brain-url.js";
 
 const pExecFile = promisify(execFile);
 
@@ -573,7 +574,7 @@ async function runCodeTask(
   const mediaPaths = codeMediaPaths(args, preparedInput.mediaPaths);
   const reasoning = parseReasoningOptions(args);
   const stepBudget = maxSteps(args);
-  const brainUrl = getStringFlag(args.flags, "brain-url") || process.env.LYNN_BRAIN_URL || "http://127.0.0.1:8790";
+  const brainUrl = await resolveDefaultBrainUrl(args);
   const mockBrain = hasFlag(args.flags, "mock-brain", "mock");
   const mode = await resolveCodeMode(args);
   const cliProvider = await resolveCliProviderProfile(args);

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -6,6 +6,7 @@ import { readVersionInfo } from "../version.js";
 import { brainRouteReadiness, fetchBrainProviderStatus, type BrainProviderStatus } from "../brain-status.js";
 import { parseBrainStreamPayload, parseSsePayloads } from "../brain-client.js";
 import { signedBrainHeaders } from "../brain-auth.js";
+import { brainEndpointUrl, resolveDefaultBrainUrl } from "../brain-url.js";
 
 export interface DoctorResult {
   ok: boolean;
@@ -35,7 +36,7 @@ export interface BrainRouteSmokeResult {
 
 export async function runDoctor(args: ParsedArgs): Promise<DoctorResult> {
   const version = readVersionInfo();
-  const brainUrl = getStringFlag(args.flags, "brain-url") || process.env.LYNN_BRAIN_URL || "http://127.0.0.1:8790";
+  const brainUrl = await resolveDefaultBrainUrl(args);
   const dataDir = resolveDataDir(getStringFlag(args.flags, "data-dir"));
   const profile = await readCliProviderProfile(dataDir);
   const profilePath = providerProfilePath(dataDir);
@@ -56,18 +57,16 @@ export async function runDoctor(args: ParsedArgs): Promise<DoctorResult> {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), 1500);
     try {
-      const res = await fetch(new URL("/health", brainUrl), { signal: ctrl.signal });
+      const res = await fetch(brainEndpointUrl(brainUrl, "/health"), { signal: ctrl.signal });
       brain = res.ok ? "ok" : "unreachable";
       checks.push({ name: "brain", ok: res.ok, message: `${res.status} ${res.statusText}`.trim() });
       if (res.ok) {
         const providerStatus = await fetchBrainProviderStatus(brainUrl, 1500);
         brainProviders = providerStatus;
-        const readiness = brainRouteReadiness(providerStatus);
-        checks.push({
-          name: "brain-route",
-          ok: readiness.usable,
-          message: readiness.message,
-        });
+        const readiness = providerStatus
+          ? brainRouteReadiness(providerStatus)
+          : { usable: true, message: "provider status unavailable; verifying route with chat smoke" };
+        checks.push({ name: "brain-route", ok: readiness.usable, message: readiness.message });
         if (readiness.usable) {
           if (hasFlag(args.flags, "no-route-smoke")) {
             checks.push({ name: "brain-smoke", ok: true, message: "skipped (--no-route-smoke)" });
@@ -118,7 +117,7 @@ export async function smokeBrainRoute(brainUrl: string, timeoutMs = 5000): Promi
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   let activeProvider = "";
   try {
-    const response = await fetch(new URL("/v1/chat/completions", brainUrl), {
+    const response = await fetch(brainEndpointUrl(brainUrl, "/v1/chat/completions"), {
       method: "POST",
       headers: {
         "content-type": "application/json",

--- a/cli/src/commands/prompt.ts
+++ b/cli/src/commands/prompt.ts
@@ -10,6 +10,7 @@ import { t } from "../i18n.js";
 import { buildImagesContentParts, parseImageList } from "../media.js";
 import { resetCliRuntimeMessages } from "../runtime-context.js";
 import { chatRouteLabel } from "./chat.js";
+import { resolveDefaultBrainUrl } from "../brain-url.js";
 
 export interface PromptOptions {
   json?: boolean;
@@ -37,7 +38,7 @@ export async function runPrompt(args: ParsedArgs, options: PromptOptions = {}): 
     throw new Error("prompt is required");
   }
   const reasoning = parseReasoningOptions(args);
-  const brainUrl = getStringFlag(args.flags, "brain-url") || process.env.LYNN_BRAIN_URL || "http://127.0.0.1:8790";
+  const brainUrl = await resolveDefaultBrainUrl(args);
   const saveSession = hasFlag(args.flags, "save-session", "session") || !!process.env.LYNN_CLI_SAVE_SESSION;
   const sessionPath = getStringFlag(args.flags, "session");
   const dataDir = resolveDataDir(getStringFlag(args.flags, "data-dir"));

--- a/cli/src/commands/providers.ts
+++ b/cli/src/commands/providers.ts
@@ -19,6 +19,7 @@ import { listProviderPresets, modelDisplayName, modelLabelWithId, resolveProvide
 import { chatCompletionsUrl } from "../brain-client.js";
 import { fetchBrainProviderStatus, summarizeBrainProviderStatus, type BrainProviderStatus } from "../brain-status.js";
 import type { ProviderPreset } from "../provider-presets.js";
+import { defaultBrainUrl, resolveDefaultBrainUrl } from "../brain-url.js";
 
 export interface ProvidersInfo {
   defaultRoute: string;
@@ -98,7 +99,7 @@ export function providersInfo(partial: Partial<ProvidersInfo> = {}): ProvidersIn
     defaultRoute: t("providers.route.default"),
     byokEntry: t("providers.byok.gui"),
     keyPolicy: t("providers.keyPolicy"),
-    brainUrl: process.env.LYNN_BRAIN_URL || "http://127.0.0.1:8790",
+    brainUrl: process.env.LYNN_BRAIN_URL || defaultBrainUrl(),
     server: { status: "missing", message: "Lynn client GUI server-info.json not found" },
     providers: [],
     presets: listProviderPresets(),
@@ -173,7 +174,7 @@ export function activeRouteLabel(info: Pick<ProvidersInfo, "activeProvider" | "a
 }
 
 export async function resolveProvidersInfo(args: ParsedArgs, timeoutMs = 1500): Promise<ProvidersInfo> {
-  const brainUrl = getStringFlag(args.flags, "brain-url") || process.env.LYNN_BRAIN_URL || "http://127.0.0.1:8790";
+  const brainUrl = await resolveDefaultBrainUrl(args);
   const dataDir = getStringFlag(args.flags, "data-dir");
   const serverUrl = getStringFlag(args.flags, "server-url") || process.env.LYNN_SERVER_URL || "";
   let lookup: LocalServerLookup = serverUrl

--- a/cli/src/commands/vision.ts
+++ b/cli/src/commands/vision.ts
@@ -8,6 +8,7 @@ import { TerminalSpinner } from "../terminal-spinner.js";
 import { resolveCliProviderProfile } from "../provider-profile.js";
 import { t } from "../i18n.js";
 import { extractGroundingBoxes, renderGroundingSummary } from "../vision-result.js";
+import { resolveDefaultBrainUrl } from "../brain-url.js";
 
 export type VisionCommand = "see" | "ground" | "ui2code";
 
@@ -17,7 +18,7 @@ export async function runVisionCommand(args: ParsedArgs, command: VisionCommand,
   if (!imagePaths.length) throw new Error(t("vision.error.imageRequired", { command }));
   const prompt = buildVisionPrompt(command, userText);
   const reasoning = parseReasoningOptions(args);
-  const brainUrl = getStringFlag(args.flags, "brain-url") || process.env.LYNN_BRAIN_URL || "http://127.0.0.1:8790";
+  const brainUrl = await resolveDefaultBrainUrl(args);
   const mockBrain = hasFlag(args.flags, "mock-brain", "mock");
   const cliProvider = await resolveCliProviderProfile(args);
 

--- a/cli/src/commands/worker-run.ts
+++ b/cli/src/commands/worker-run.ts
@@ -19,6 +19,7 @@ import { buildVisionPrompt, type VisionCommand } from "./vision.js";
 import { nowIso, writeJsonLine } from "../jsonl.js";
 import { readEnvProviderProfile, resolveCliProviderProfile } from "../provider-profile.js";
 import { resolveEffectivePermissions, type PermissionProfile } from "../permissions.js";
+import { resolveDefaultBrainUrl } from "../brain-url.js";
 export { extractGroundingBoxes } from "../vision-result.js";
 import { extractGroundingBoxes } from "../vision-result.js";
 
@@ -728,7 +729,7 @@ async function runLynnAnswerOnlyWorker(input: {
 }): Promise<number> {
   emit({ type: "shell.started", workerId: input.workerId, agent: input.agent, command: "Lynn answer", approval: "auto" });
   const started = Date.now();
-  const brainUrl = getStringFlag(input.args.flags, "brain-url") || process.env.LYNN_BRAIN_URL || "http://127.0.0.1:8790";
+  const brainUrl = await resolveDefaultBrainUrl(input.args);
   const profileDefaults = workerProfileDefaults(input.agent);
   const reasoning = parseReasoningOptions({
     ...input.args,
@@ -821,7 +822,7 @@ async function runLynnVisionWorker(input: {
   const imagePath = path.isAbsolute(input.brief.image) ? input.brief.image : path.resolve(input.worktree, input.brief.image);
   const prompt = buildVisionPrompt(input.brief.taskType, input.brief.objective || input.brief.title);
   const content = await buildImageContentParts(imagePath, prompt);
-  const brainUrl = getStringFlag(input.args.flags, "brain-url") || process.env.LYNN_BRAIN_URL || "http://127.0.0.1:8790";
+  const brainUrl = await resolveDefaultBrainUrl(input.args);
   const profileDefaults = workerProfileDefaults(input.agent);
   const reasoning = parseReasoningOptions({
     ...input.args,

--- a/cli/src/ink-chat.ts
+++ b/cli/src/ink-chat.ts
@@ -23,6 +23,7 @@ import { buildImagesContentParts } from "./media.js";
 import { buildMemoryContextFrameSync, handleMemorySlashCommand } from "./session/memory.js";
 import { resolveDataDir } from "./session/store.js";
 import { rotatingPlaceholder } from "./ink-placeholders.js";
+import { resolveDefaultBrainUrl } from "./brain-url.js";
 
 type Turn = {
   id: number;
@@ -44,7 +45,7 @@ interface InkChatProps {
 
 export async function runInkChat(args: ParsedArgs): Promise<number> {
   const mockBrain = hasFlag(args.flags, "mock-brain", "mock");
-  const brainUrl = getStringFlag(args.flags, "brain-url") || process.env.LYNN_BRAIN_URL || "http://127.0.0.1:8790";
+  const brainUrl = await resolveDefaultBrainUrl(args);
   const initialReasoning = parseReasoningOptions(args);
   const permissions = await resolveEffectivePermissions(args);
   const initialMode: ChatMode = { approval: permissions.approval, sandbox: permissions.sandbox };

--- a/cli/tests/brain-client.test.ts
+++ b/cli/tests/brain-client.test.ts
@@ -4,6 +4,7 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { BrainConnectionError, chatCompletionsUrl, checkBrainReachable, parseBrainStreamPayload, parseSsePayloads, streamBrainChat } from "../src/brain-client.js";
+import { brainEndpointUrl, HOSTED_BRAIN_URL, LOCAL_BRAIN_URL, resolveDefaultBrainUrl } from "../src/brain-url.js";
 import { parseArgs } from "../src/args.js";
 import { applyReasoningToBody, parseReasoningOptions, shouldRenderReasoning } from "../src/reasoning.js";
 import { setLang } from "../src/i18n.js";
@@ -164,6 +165,42 @@ describe("brain-client stream parser", () => {
 
   it("returns false when the Brain health probe cannot connect", async () => {
     await expect(checkBrainReachable("http://127.0.0.1:1", 50)).resolves.toBe(false);
+  });
+
+  it("preserves hosted Brain path prefixes when building endpoints", () => {
+    expect(brainEndpointUrl("https://api.merkyorlynn.com/api/v2", "/health").toString())
+      .toBe("https://api.merkyorlynn.com/api/v2/health");
+    expect(brainEndpointUrl("https://api.merkyorlynn.com/api/v2/", "/v1/chat/completions").toString())
+      .toBe("https://api.merkyorlynn.com/api/v2/v1/chat/completions");
+  });
+
+  it("prefers hosted Brain for default startup when reachable", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: URL | string) => {
+      const href = String(url);
+      if (href === `${HOSTED_BRAIN_URL}/health`) return new Response("{}", { status: 200 });
+      return new Response("nope", { status: 500 });
+    }) as typeof fetch;
+    try {
+      await expect(resolveDefaultBrainUrl(undefined, 50)).resolves.toBe(HOSTED_BRAIN_URL);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("falls back to local Brain when hosted Brain is unreachable", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: URL | string) => {
+      const href = String(url);
+      if (href === `${HOSTED_BRAIN_URL}/health`) throw new Error("hosted down");
+      if (href === `${LOCAL_BRAIN_URL}/health`) return new Response("{}", { status: 200 });
+      return new Response("nope", { status: 500 });
+    }) as typeof fetch;
+    try {
+      await expect(resolveDefaultBrainUrl(undefined, 50)).resolves.toBe(LOCAL_BRAIN_URL);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("falls back to a CLI BYOK OpenAI-compatible provider when Brain is offline", async () => {

--- a/cli/tests/doctor.test.ts
+++ b/cli/tests/doctor.test.ts
@@ -62,6 +62,33 @@ describe("doctor command", () => {
     expect(rendered).toContain("brain-smoke: route returned assistant output via step-3.7-flash");
   });
 
+  it("uses chat smoke when hosted Brain does not expose provider route status", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (url: URL | string) => {
+      const href = String(url);
+      if (href.endsWith("/health")) return new Response(JSON.stringify({ ok: true }), { status: 200, statusText: "OK" });
+      if (href.endsWith("/v1/providers/status")) return new Response("not found", { status: 404, statusText: "Not Found" });
+      if (href.endsWith("/v1/chat/completions")) {
+        return new Response([
+          'data: {"object":"lynn.provider","meta":{"active_provider":"mimo"}}',
+          "",
+          'data: {"choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}',
+          "",
+        ].join("\n"), { status: 200, statusText: "OK" });
+      }
+      return new Response("not found", { status: 404, statusText: "Not Found" });
+    }));
+
+    const result = await runDoctor(parseArgs(["doctor", "--brain-url", "https://api.merkyorlynn.com/api/v2"]));
+    const rendered = renderDoctor(result);
+
+    expect(result.brain).toBe("ok");
+    expect(result.ok).toBe(true);
+    expect(result.brainProviders).toBeNull();
+    expect(result.brainSmoke).toMatchObject({ ok: true, provider: "mimo" });
+    expect(rendered).toContain("brain-route: provider status unavailable; verifying route with chat smoke");
+    expect(rendered).toContain("brain-smoke: route returned assistant output via mimo");
+  });
+
   it("fails Brain route diagnostics when no provider in the route is configured", async () => {
     vi.stubGlobal("fetch", vi.fn(async (url: URL | string) => {
       const href = String(url);


### PR DESCRIPTION
## Summary\n- default standalone CLI startup to hosted Brain V2 at https://api.merkyorlynn.com/api/v2, with local Brain fallback\n- preserve /api/v2 path prefixes for health/chat/provider endpoints\n- make doctor use chat smoke when hosted provider status is unavailable\n\n## Verification\n- npm --prefix cli run typecheck\n- npm --prefix cli test\n- npm --prefix cli run build\n- npm install -g --force https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.0.tgz\n- Lynn doctor\n- Lynn -p "回复 OK" --reasoning off\n