### PR TITLE
docs: lead README with V0.80 CLI Worker Fleet + sync agent contract to v0.80.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,6 @@
 
 ---
 
-## 🧠 Lynn 模型与引擎路线
-
-Lynn 现在不只是桌面端 Agent。配套的模型、量化和自研推理引擎已经形成一条独立路线,用于把 Lynn 的本地长期记忆 / 多 Agent / 工具调用能力跑在可控的私有模型栈上。
-
-| 方向 | 当前状态 |
-|---|---|
-| **Lynn V4 / V Flash 35B-A3B** | BF16 / NVFP4 / Q4_K_M 变体已完成发布与回归;Q4 工具调用模板热修已同步 HF / ModelScope。 |
-| **Lynn 27B-A3B 基座** | 从 Qwen3.6-35B-A3B BASE 走 variable-expert pruning + Router-FT + Recovery LoRA,当前选定 **step5000 final**。BF16 评测:V8 strict 33/34 = 97.06%,V9 adjusted 37/59 = 62.71%。 |
-| **Lynn-native NVFP4** | 27B variable-expert NVFP4 artifact 约 20GB,用于 Lynn Engine 自研 runtime。它不是 GGUF,也不是公开通用框架的 compressed-tensors v8-RTN。 |
-| **Lynn Engine** | 自研 Blackwell/R6000 推理引擎已跑通 27B NVFP4。当前 R6000 strict full path **103.44 tok/s**,serving replay **107.23 tok/s**;下一目标是生产稳定 100+ TPS 与 native FP4 kernel。 |
-
-相关仓库:
-- [MerkyorLynn/lynn-engine](https://github.com/MerkyorLynn/lynn-engine):Lynn 27B-A3B NVFP4 自研推理引擎。
-- [MerkyorLynn/lynn-distill-toolkit](https://github.com/MerkyorLynn/lynn-distill-toolkit):蒸馏、评测、量化与发布工具链。
-
-> 说明:27B Lynn-native NVFP4 是给 Lynn Engine 的内部/垂直 runtime artifact;通用用户仍建议从 V4 / V Flash 的 BF16、NVFP4 v8-RTN 或 Q4_K_M 版本开始。
-
 ## 🔭 V0.80:GUI + CLI Worker Fleet
 
 V0.80 把 Lynn 带回编程主战场,但不是再做一个单 CLI 或 IDE 插件。Lynn 的方向是把 **GUI 变成多个 CLI Agent 的指挥台**:你可以在图形界面里拆任务、派发给不同 CLI worker、查看日志和 diff、跑门禁、合并或丢弃结果。
@@ -110,6 +93,23 @@ Lynn worker run --brief task.md --worktree . --agent qwen-cli --jsonl
 一个 `--agent` 把任务派给 Codex / Claude Code / Qwen / Kimi / CodeBuddy / OpenCode 或 Lynn 自身,统一吐 Fleet JSONL。安全边界守在 Lynn 侧(ownership / forbidden-glob / diff 校验 / gate),不依赖外部 worker 自觉。
 
 成功信号 = `gate.finished.ok`;硬失败 = `worker.violation` 或 `worker.error{recoverable:false}`。完整规范(BYOK 配置 / agent 适配表 / 全事件 schema / code tools)见 [`docs/ops/lynn-cli-agent-contract.md`](docs/ops/lynn-cli-agent-contract.md)。
+
+## 🧠 Lynn 模型与引擎路线
+
+Lynn 现在不只是桌面端 Agent。配套的模型、量化和自研推理引擎已经形成一条独立路线,用于把 Lynn 的本地长期记忆 / 多 Agent / 工具调用能力跑在可控的私有模型栈上。
+
+| 方向 | 当前状态 |
+|---|---|
+| **Lynn V4 / V Flash 35B-A3B** | BF16 / NVFP4 / Q4_K_M 变体已完成发布与回归;Q4 工具调用模板热修已同步 HF / ModelScope。 |
+| **Lynn 27B-A3B 基座** | 从 Qwen3.6-35B-A3B BASE 走 variable-expert pruning + Router-FT + Recovery LoRA,当前选定 **step5000 final**。BF16 评测:V8 strict 33/34 = 97.06%,V9 adjusted 37/59 = 62.71%。 |
+| **Lynn-native NVFP4** | 27B variable-expert NVFP4 artifact 约 20GB,用于 Lynn Engine 自研 runtime。它不是 GGUF,也不是公开通用框架的 compressed-tensors v8-RTN。 |
+| **Lynn Engine** | 自研 Blackwell/R6000 推理引擎已跑通 27B NVFP4。当前 R6000 strict full path **103.44 tok/s**,serving replay **107.23 tok/s**;下一目标是生产稳定 100+ TPS 与 native FP4 kernel。 |
+
+相关仓库:
+- [MerkyorLynn/lynn-engine](https://github.com/MerkyorLynn/lynn-engine):Lynn 27B-A3B NVFP4 自研推理引擎。
+- [MerkyorLynn/lynn-distill-toolkit](https://github.com/MerkyorLynn/lynn-distill-toolkit):蒸馏、评测、量化与发布工具链。
+
+> 说明:27B Lynn-native NVFP4 是给 Lynn Engine 的内部/垂直 runtime artifact;通用用户仍建议从 V4 / V Flash 的 BF16、NVFP4 v8-RTN 或 Q4_K_M 版本开始。
 
 ## 🆕 近期更新
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -18,23 +18,6 @@
 
 ---
 
-## 🧠 Lynn Models And Engine Roadmap
-
-Lynn is no longer only a desktop agent. The project now has a companion model, quantization, and custom inference stack so Lynn's local memory, multi-agent workflow, and tool-calling path can run on a model stack we fully own.
-
-| Track | Current status |
-|---|---|
-| **Lynn V4 / V Flash 35B-A3B** | BF16 / NVFP4 / Q4_K_M variants have been shipped and regression-tested. The Q4 tool-calling template hotfix has been pushed to Hugging Face and ModelScope. |
-| **Lynn 27B-A3B base** | Built from Qwen3.6-35B-A3B BASE through variable-expert pruning + Router-FT + Recovery LoRA. The selected base is **step5000 final**. BF16 eval:V8 strict 33/34 = 97.06%,V9 adjusted 37/59 = 62.71%. |
-| **Lynn-native NVFP4** | The 27B variable-expert NVFP4 artifact is about 20GB and targets Lynn Engine directly. It is not GGUF and not the public compressed-tensors v8-RTN format used by generic serving stacks. |
-| **Lynn Engine** | Custom Blackwell/R6000 runtime for 27B NVFP4. Current R6000 strict full path reaches **103.44 tok/s**,with serving replay at **107.23 tok/s**. Next target:production-stable 100+ TPS and native FP4 kernels. |
-
-Related repositories:
-- [MerkyorLynn/lynn-engine](https://github.com/MerkyorLynn/lynn-engine):custom Lynn 27B-A3B NVFP4 inference engine.
-- [MerkyorLynn/lynn-distill-toolkit](https://github.com/MerkyorLynn/lynn-distill-toolkit):distillation, evaluation, quantization, and release toolkit.
-
-> Note:the 27B Lynn-native NVFP4 artifact is an internal/vertical runtime artifact for Lynn Engine. General users should start with the V4 / V Flash BF16, NVFP4 v8-RTN, or Q4_K_M variants.
-
 ## 🔭 V0.80: GUI + CLI Worker Fleet
 
 V0.80 brings Lynn back to the programming battlefield, but not as another single CLI or IDE plugin. The direction is to make **the GUI a command center for multiple CLI agents**: split tasks, dispatch workers, inspect logs and diffs, run gates, then merge or discard the result from one visual workflow.
@@ -78,6 +61,23 @@ Lynn code -p "fix tests, run the suite, summarize the diff" \
 ```
 
 Agents should parse JSONL, not the human Ink TUI. See [`docs/ops/lynn-code-headless-agent-contract.md`](docs/ops/lynn-code-headless-agent-contract.md).
+
+## 🧠 Lynn Models And Engine Roadmap
+
+Lynn is no longer only a desktop agent. The project now has a companion model, quantization, and custom inference stack so Lynn's local memory, multi-agent workflow, and tool-calling path can run on a model stack we fully own.
+
+| Track | Current status |
+|---|---|
+| **Lynn V4 / V Flash 35B-A3B** | BF16 / NVFP4 / Q4_K_M variants have been shipped and regression-tested. The Q4 tool-calling template hotfix has been pushed to Hugging Face and ModelScope. |
+| **Lynn 27B-A3B base** | Built from Qwen3.6-35B-A3B BASE through variable-expert pruning + Router-FT + Recovery LoRA. The selected base is **step5000 final**. BF16 eval:V8 strict 33/34 = 97.06%,V9 adjusted 37/59 = 62.71%. |
+| **Lynn-native NVFP4** | The 27B variable-expert NVFP4 artifact is about 20GB and targets Lynn Engine directly. It is not GGUF and not the public compressed-tensors v8-RTN format used by generic serving stacks. |
+| **Lynn Engine** | Custom Blackwell/R6000 runtime for 27B NVFP4. Current R6000 strict full path reaches **103.44 tok/s**,with serving replay at **107.23 tok/s**. Next target:production-stable 100+ TPS and native FP4 kernels. |
+
+Related repositories:
+- [MerkyorLynn/lynn-engine](https://github.com/MerkyorLynn/lynn-engine):custom Lynn 27B-A3B NVFP4 inference engine.
+- [MerkyorLynn/lynn-distill-toolkit](https://github.com/MerkyorLynn/lynn-distill-toolkit):distillation, evaluation, quantization, and release toolkit.
+
+> Note:the 27B Lynn-native NVFP4 artifact is an internal/vertical runtime artifact for Lynn Engine. General users should start with the V4 / V Flash BF16, NVFP4 v8-RTN, or Q4_K_M variants.
 
 ## 🆕 Recent Updates
 

--- a/docs/ops/lynn-cli-agent-contract.md
+++ b/docs/ops/lynn-cli-agent-contract.md
@@ -1,8 +1,8 @@
 # Lynn CLI · Agent Quick Contract
 
 > Machine-readable invocation spec for orchestrators and Fleet workers.
-> Command is `Lynn` (uppercase primary, `lynn` lowercase alias).
-> v0.80 alpha. Verified against `cli/` on branch `claude/v080-cli-gaps`.
+> Command is `Lynn` (uppercase; `lynn` also resolves on case-insensitive filesystems like macOS — use `Lynn` on Linux/CI).
+> v0.80.0. Verified against `cli/` on branch `codex/v0801-stability`.
 
 ---
 
@@ -19,7 +19,7 @@ npm install -g --force https://download.merkyorlynn.com/downloads/cli/lynn-cli-l
 
 `--force` lets npm replace an older `Lynn`/`lynn` shim. Requires Node ≥ 20.
 
-**Routing:** GUI running → local Lynn server / Brain chain (default MiMo, full cascade + Fleet).
+**Routing:** GUI running → local Lynn server / Brain chain (default StepFun 3.7 Flash, full StepFun → MiMo → Spark cascade + Fleet).
 GUI not running → user-owned BYOK endpoint (`Lynn providers set`).
 
 ---
@@ -102,6 +102,7 @@ approval — they do not relax Lynn's boundary checks.
 Newline-delimited JSON. Every event carries `workerId` and `agent`.
 
 ```jsonl
+{"type":"worker.started","workerId":"w1","agent":"step-3.7","cwd":".","worktree":".","branch":"fleet/w1","approval":"yolo","sandbox":"workspace-write"}
 {"type":"reasoning.delta","workerId":"w1","agent":"step-3.7","text":"...","hidden":true}
 {"type":"assistant.delta","workerId":"w1","agent":"step-3.7","text":"Here is the fix..."}
 {"type":"tool.started","workerId":"w1","agent":"step-3.7","name":"write_file"}
@@ -116,6 +117,7 @@ Newline-delimited JSON. Every event carries `workerId` and `agent`.
 {"type":"worker.progress","workerId":"w1","agent":"codex-cli","text":"raw stdout line"}
 {"type":"worker.violation","workerId":"w1","agent":"step-3.7","...":"ownership/glob breach"}
 {"type":"worker.error","workerId":"w1","agent":"step-3.7","code":"worker_exit_nonzero","message":"...","recoverable":true}
+{"type":"worker.finished","workerId":"w1","agent":"step-3.7","ok":true,"exitCode":0,"summary":"...","commit":"a1b2c3d"}
 ```
 
 **Event types:**
@@ -129,15 +131,18 @@ Newline-delimited JSON. Every event carries `workerId` and `agent`.
 | `test.started` / `test.finished` | test run | `command`, `ok`, `summary`, `ms` |
 | `git.diff` | resulting diff | diff payload |
 | `gate.finished` | Lynn-side validation gate | `ok` |
+| `worker.started` | worker lifecycle begin | `workerId`, `cwd`, `worktree`, `branch` (opt `pid`, `command`, `approval`, `sandbox`) |
 | `worker.progress` | wrapped external agent raw output | `text` |
 | `worker.violation` | ownership / forbidden-glob breach | breach detail |
 | `worker.error` | worker failure | `code`, `message`, `recoverable` |
+| `worker.finished` | worker lifecycle end (terminal) | `ok`, `exitCode`, `summary` (opt `commit`) |
 
 **Orchestrator parse pattern:**
 - Answer = concat `assistant.delta.text`
 - Success signal = `gate.finished.ok === true` (or final `shell/test.finished.ok`)
 - Hard fail = any `worker.violation`, or `worker.error` with `recoverable:false`
 - Non-zero worker exit → `worker.error` `code:"worker_exit_nonzero"`
+- Lifecycle bookends = `worker.started` (begin) … `worker.finished` (terminal; carries final `ok` / `exitCode` / optional `commit`)
 
 ---
 
@@ -163,4 +168,4 @@ Lynn -p "ping" --json                    # end-to-end smoke
 
 ---
 
-*Contract v0.2 · Lynn CLI v0.80 alpha · verified against cli/ source 2026-05-31*
+*Contract v0.3 · Lynn CLI v0.80.0 · verified against cli/ source 2026-05-31*


### PR DESCRIPTION
Two doc-only changes for the **V0.80.0** release — the center of this version is the CLI, so the docs should lead with it.

## 📄 README (`ff06a2e`)
Swap the first two content sections in `README.md` and `README_EN.md` so the first screen is **🔭 V0.80: GUI + CLI Worker Fleet** and **🧠 Lynn Models And Engine Roadmap** follows it instead of leading. Pure position swap — section content is unchanged.

## 📄 Agent contract (`2e80ee1`)
Sync `docs/ops/lynn-cli-agent-contract.md` to v0.80.0:
- **Routing default `MiMo` → `StepFun 3.7 Flash`** (matches `provider-registry` `universalOrder` head — StepFun-first landed in 9269ae1).
- **`v0.80 alpha` → `v0.80.0`**; contract `v0.2 → v0.3`.
- **Document `worker.started` / `worker.finished`** — both canonical in `shared/fleet-events.ts` but were missing from the event table, JSONL example, and orchestrator parse pattern (added lifecycle bookends + final `ok`/`exitCode`/`commit`).
- Clarify `lynn` lowercase only resolves on case-insensitive filesystems (use `Lynn` on Linux/CI).

---

Docs only, no code changes. `main`'s base of all three files matches these commits, so this PR's diff is **exactly** the two commits above (README 34±, README_EN 34±, contract 9+/4−).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
