### PR TITLE
fix(cli): stabilize v0.80.3 terminal renderer

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lynn/cli",
-  "version": "0.80.2",
+  "version": "0.80.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lynn/cli",
-      "version": "0.80.2",
+      "version": "0.80.3",
       "license": "Apache-2.0",
       "dependencies": {
         "ink": "6.4.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynn/cli",
-  "version": "0.80.2",
+  "version": "0.80.3",
   "private": false,
   "type": "module",
   "description": "Lynn command line interface and worker runner",
@@ -18,6 +18,7 @@
     "build": "node scripts/build.mjs",
     "preinstall": "node scripts/preinstall.mjs",
     "prepack": "npm run build",
+    "stress:cli": "npm run build && node scripts/stress-cli.mjs",
     "test": "vitest run tests --reporter=dot",
     "typecheck": "tsc --noEmit"
   },

--- a/cli/scripts/stress-cli.mjs
+++ b/cli/scripts/stress-cli.mjs
@@ -23,12 +23,13 @@ await Promise.all(Array.from({ length: parallel }, (_, i) => runPromptVersion(i 
 for (let i = 0; i < Math.max(4, Math.floor(serial / 4)); i += 1) {
   await runCodePromptVersion(i);
 }
+await runPromptNonVersionSmoke();
 
 if (process.platform !== "win32") {
   await runAppleTerminalStablePty();
 }
 
-console.log(`[stress-cli] ok: ${serial} serial + ${parallel} parallel -p runs + code -p local checks${process.platform === "win32" ? "" : " + Apple Terminal stable PTY"}`);
+console.log(`[stress-cli] ok: ${serial} serial + ${parallel} parallel -p runs + code -p local checks + non-version smoke${process.platform === "win32" ? "" : " + Apple Terminal stable PTY"}`);
 
 async function runPromptVersion(index) {
   const result = await run(process.execPath, [bin, "-p", index % 2 ? "what version are you?" : "你的版本号", "--json", "--brain-url", "http://127.0.0.1:1"], {
@@ -70,6 +71,26 @@ async function runCodePromptVersion(index) {
   }
 }
 
+async function runPromptNonVersionSmoke() {
+  const result = await run(process.execPath, [bin, "-p", "write a semantic version comparator", "--mock-brain", "--json", "--brain-url", "http://127.0.0.1:1"], {
+    env: {
+      ...process.env,
+      LYNN_LANG: "en",
+      NO_COLOR: "1",
+    },
+    timeoutMs: 10_000,
+  });
+  if (result.code !== 0) {
+    throw new Error(`non-version smoke exited ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+  if (result.stdout.includes('"local":true') || /Lynn CLI (版本|version)/.test(result.stdout)) {
+    throw new Error(`non-version smoke was incorrectly intercepted as runtime question:\n${result.stdout}`);
+  }
+  if (!/Mock (Lynn response|reply)/.test(result.stdout)) {
+    throw new Error(`non-version smoke did not reach mock brain path:\n${result.stdout}`);
+  }
+}
+
 async function runAppleTerminalStablePty() {
   const python = await findPython();
   if (!python) {
@@ -95,6 +116,7 @@ proc = subprocess.Popen([node_bin, cli_bin], stdin=slave, stdout=slave, stderr=s
 os.close(slave)
 buf = b""
 sent_version = False
+sent_yolo = False
 sent_exit = False
 deadline = time.time() + 20
 while time.time() < deadline:
@@ -111,7 +133,10 @@ while time.time() < deadline:
         if (not sent_version) and ("Lynn CLI" in text) and ("›" in text or ">" in text):
             os.write(master, "/version\r".encode("utf-8"))
             sent_version = True
-        elif sent_version and (not sent_exit) and ("Lynn CLI 版本" in text or "Lynn CLI version" in text) and ("›" in text or ">" in text):
+        elif sent_version and (not sent_yolo) and ("Lynn CLI 版本" in text or "Lynn CLI version" in text) and ("›" in text or ">" in text):
+            os.write(master, "/yolo\r".encode("utf-8"))
+            sent_yolo = True
+        elif sent_yolo and (not sent_exit) and ("yolo" in text.lower()) and ("›" in text or ">" in text):
             os.write(master, "/exit\r".encode("utf-8"))
             sent_exit = True
     if sent_exit and proc.poll() is not None:
@@ -131,6 +156,8 @@ if "Lynn CLI 版本" not in text and "Lynn CLI version" not in text:
     sys.exit(13)
 if "fetch failed" in text or "all providers failed" in text:
     sys.exit(14)
+if "yolo" not in text.lower():
+    sys.exit(15)
 sys.exit(0)
 `;
   const result = await run(python, ["-c", script, process.execPath, bin], {

--- a/cli/scripts/stress-cli.mjs
+++ b/cli/scripts/stress-cli.mjs
@@ -27,9 +27,10 @@ await runPromptNonVersionSmoke();
 
 if (process.platform !== "win32") {
   await runAppleTerminalStablePty();
+  await runAppleTerminalMockConversationPty();
 }
 
-console.log(`[stress-cli] ok: ${serial} serial + ${parallel} parallel -p runs + code -p local checks + non-version smoke${process.platform === "win32" ? "" : " + Apple Terminal stable PTY"}`);
+console.log(`[stress-cli] ok: ${serial} serial + ${parallel} parallel -p runs + code -p local checks + non-version smoke${process.platform === "win32" ? "" : " + Apple Terminal stable PTY + Apple Terminal mock conversation"}`);
 
 async function runPromptVersion(index) {
   const result = await run(process.execPath, [bin, "-p", index % 2 ? "what version are you?" : "你的版本号", "--json", "--brain-url", "http://127.0.0.1:1"], {
@@ -136,7 +137,7 @@ while time.time() < deadline:
         elif sent_version and (not sent_yolo) and ("Lynn CLI 版本" in text or "Lynn CLI version" in text) and ("›" in text or ">" in text):
             os.write(master, "/yolo\r".encode("utf-8"))
             sent_yolo = True
-        elif sent_yolo and (not sent_exit) and ("yolo" in text.lower()) and ("›" in text or ">" in text):
+        elif sent_yolo and (not sent_exit) and ("YOLO 静默" in text or "danger-full-access" in text or "zero-prompt" in text) and ("›" in text or ">" in text):
             os.write(master, "/exit\r".encode("utf-8"))
             sent_exit = True
     if sent_exit and proc.poll() is not None:
@@ -166,6 +167,86 @@ sys.exit(0)
   });
   if (result.code !== 0) {
     throw new Error(`Apple Terminal stable PTY stress exited ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+}
+
+async function runAppleTerminalMockConversationPty() {
+  const python = await findPython();
+  if (!python) {
+    console.log("[stress-cli] skip Apple Terminal mock conversation: python3 not found");
+    return;
+  }
+  const script = String.raw`
+import os
+import pty
+import select
+import subprocess
+import sys
+import time
+
+node_bin, cli_bin = sys.argv[1], sys.argv[2]
+master, slave = pty.openpty()
+env = os.environ.copy()
+env["TERM_PROGRAM"] = "Apple_Terminal"
+env["NO_COLOR"] = "1"
+env["LYNN_LANG"] = "zh"
+env["LYNN_BRAIN_URL"] = "http://127.0.0.1:1"
+proc = subprocess.Popen([node_bin, cli_bin, "--mock-brain"], stdin=slave, stdout=slave, stderr=slave, env=env, close_fds=True)
+os.close(slave)
+buf = b""
+steps = [
+    ("你好,测试中文输入", "模拟回复"),
+    ("/think", "思考模式"),
+    ("/reasoning off", "推理强度已设为 off"),
+    ("/yolo", "YOLO 静默"),
+    ("/help", "/exit"),
+    ("/exit", None),
+]
+sent = 0
+deadline = time.time() + 35
+while time.time() < deadline:
+    readable, _, _ = select.select([master], [], [], 0.1)
+    if readable:
+        try:
+            chunk = os.read(master, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        buf += chunk
+        text = buf.decode("utf-8", errors="replace")
+        if sent < len(steps) and ("›" in text or ">" in text) and (sent == 0 or steps[sent - 1][1] is None or steps[sent - 1][1] in text):
+            command, _ = steps[sent]
+            os.write(master, (command + "\r").encode("utf-8"))
+            sent += 1
+    if sent >= len(steps) and proc.poll() is not None:
+        break
+if proc.poll() is None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+text = buf.decode("utf-8", errors="replace")
+sys.stdout.write(text)
+if proc.returncode not in (0, None):
+    sys.exit(proc.returncode)
+required = ["模拟回复", "思考模式", "推理强度已设为 off", "yolo", "/exit"]
+missing = [item for item in required if item.lower() not in text.lower()]
+if missing:
+    sys.stderr.write("missing expected Apple Terminal mock markers: " + ", ".join(missing) + "\n")
+    sys.exit(16)
+if "fetch failed" in text or "all providers failed" in text:
+    sys.exit(17)
+sys.exit(0)
+`;
+  const result = await run(python, ["-c", script, process.execPath, bin], {
+    env: process.env,
+    timeoutMs: 40_000,
+  });
+  if (result.code !== 0) {
+    throw new Error(`Apple Terminal mock conversation stress exited ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
   }
 }
 

--- a/cli/scripts/stress-cli.mjs
+++ b/cli/scripts/stress-cli.mjs
@@ -20,12 +20,15 @@ for (let i = 0; i < serial; i += 1) {
   await runPromptVersion(i);
 }
 await Promise.all(Array.from({ length: parallel }, (_, i) => runPromptVersion(i + serial)));
+for (let i = 0; i < Math.max(4, Math.floor(serial / 4)); i += 1) {
+  await runCodePromptVersion(i);
+}
 
 if (process.platform !== "win32") {
   await runAppleTerminalStablePty();
 }
 
-console.log(`[stress-cli] ok: ${serial} serial + ${parallel} parallel -p runs${process.platform === "win32" ? "" : " + Apple Terminal stable PTY"}`);
+console.log(`[stress-cli] ok: ${serial} serial + ${parallel} parallel -p runs + code -p local checks${process.platform === "win32" ? "" : " + Apple Terminal stable PTY"}`);
 
 async function runPromptVersion(index) {
   const result = await run(process.execPath, [bin, "-p", index % 2 ? "what version are you?" : "你的版本号", "--json", "--brain-url", "http://127.0.0.1:1"], {
@@ -44,6 +47,26 @@ async function runPromptVersion(index) {
   }
   if (/fetch failed|Brain offline|all providers failed/i.test(result.stdout + result.stderr)) {
     throw new Error(`-p stress ${index} unexpectedly contacted Brain:\n${result.stdout}\n${result.stderr}`);
+  }
+}
+
+async function runCodePromptVersion(index) {
+  const result = await run(process.execPath, [bin, "code", "-p", index % 2 ? "what version are you?" : "你的版本号", "--json", "--brain-url", "http://127.0.0.1:1"], {
+    env: {
+      ...process.env,
+      LYNN_LANG: index % 2 ? "en" : "zh",
+      NO_COLOR: "1",
+    },
+    timeoutMs: 10_000,
+  });
+  if (result.code !== 0) {
+    throw new Error(`code -p stress ${index} exited ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+  if (!result.stdout.includes('"local":true') || !/Lynn CLI (版本|version)/.test(result.stdout)) {
+    throw new Error(`code -p stress ${index} did not use local runtime answer:\n${result.stdout}`);
+  }
+  if (/fetch failed|Brain offline|all providers failed/i.test(result.stdout + result.stderr)) {
+    throw new Error(`code -p stress ${index} unexpectedly contacted Brain:\n${result.stdout}\n${result.stderr}`);
   }
 }
 

--- a/cli/scripts/stress-cli.mjs
+++ b/cli/scripts/stress-cli.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const bin = path.join(root, "bin", "lynn.mjs");
+
+if (!existsSync(bin)) {
+  console.error(`[stress-cli] missing ${bin}; run npm --prefix cli run build first`);
+  process.exit(1);
+}
+
+const serial = Number.parseInt(process.env.LYNN_CLI_STRESS_SERIAL || "40", 10);
+const parallel = Number.parseInt(process.env.LYNN_CLI_STRESS_PARALLEL || "8", 10);
+
+for (let i = 0; i < serial; i += 1) {
+  await runPromptVersion(i);
+}
+await Promise.all(Array.from({ length: parallel }, (_, i) => runPromptVersion(i + serial)));
+
+if (process.platform !== "win32") {
+  await runAppleTerminalStablePty();
+}
+
+console.log(`[stress-cli] ok: ${serial} serial + ${parallel} parallel -p runs${process.platform === "win32" ? "" : " + Apple Terminal stable PTY"}`);
+
+async function runPromptVersion(index) {
+  const result = await run(process.execPath, [bin, "-p", index % 2 ? "what version are you?" : "你的版本号", "--json", "--brain-url", "http://127.0.0.1:1"], {
+    env: {
+      ...process.env,
+      LYNN_LANG: index % 2 ? "en" : "zh",
+      NO_COLOR: "1",
+    },
+    timeoutMs: 10_000,
+  });
+  if (result.code !== 0) {
+    throw new Error(`-p stress ${index} exited ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+  if (!result.stdout.includes('"local":true') || !/Lynn CLI (版本|version)/.test(result.stdout)) {
+    throw new Error(`-p stress ${index} did not use local runtime answer:\n${result.stdout}`);
+  }
+  if (/fetch failed|Brain offline|all providers failed/i.test(result.stdout + result.stderr)) {
+    throw new Error(`-p stress ${index} unexpectedly contacted Brain:\n${result.stdout}\n${result.stderr}`);
+  }
+}
+
+async function runAppleTerminalStablePty() {
+  const python = await findPython();
+  if (!python) {
+    console.log("[stress-cli] skip Apple Terminal PTY: python3 not found");
+    return;
+  }
+  const script = String.raw`
+import os
+import pty
+import select
+import subprocess
+import sys
+import time
+
+node_bin, cli_bin = sys.argv[1], sys.argv[2]
+master, slave = pty.openpty()
+env = os.environ.copy()
+env["TERM_PROGRAM"] = "Apple_Terminal"
+env["NO_COLOR"] = "1"
+env["LYNN_LANG"] = "zh"
+env["LYNN_BRAIN_URL"] = "http://127.0.0.1:1"
+proc = subprocess.Popen([node_bin, cli_bin], stdin=slave, stdout=slave, stderr=slave, env=env, close_fds=True)
+os.close(slave)
+buf = b""
+sent_version = False
+sent_exit = False
+deadline = time.time() + 20
+while time.time() < deadline:
+    readable, _, _ = select.select([master], [], [], 0.1)
+    if readable:
+        try:
+            chunk = os.read(master, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        buf += chunk
+        text = buf.decode("utf-8", errors="replace")
+        if (not sent_version) and ("Lynn CLI" in text) and ("›" in text or ">" in text):
+            os.write(master, "/version\r".encode("utf-8"))
+            sent_version = True
+        elif sent_version and (not sent_exit) and ("Lynn CLI 版本" in text or "Lynn CLI version" in text) and ("›" in text or ">" in text):
+            os.write(master, "/exit\r".encode("utf-8"))
+            sent_exit = True
+    if sent_exit and proc.poll() is not None:
+        break
+if proc.poll() is None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+text = buf.decode("utf-8", errors="replace")
+sys.stdout.write(text)
+if proc.returncode not in (0, None):
+    sys.exit(proc.returncode)
+if "Lynn CLI 版本" not in text and "Lynn CLI version" not in text:
+    sys.exit(13)
+if "fetch failed" in text or "all providers failed" in text:
+    sys.exit(14)
+sys.exit(0)
+`;
+  const result = await run(python, ["-c", script, process.execPath, bin], {
+    env: process.env,
+    timeoutMs: 25_000,
+  });
+  if (result.code !== 0) {
+    throw new Error(`Apple Terminal stable PTY stress exited ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+}
+
+async function findPython() {
+  for (const candidate of ["python3", "python"]) {
+    const result = await run(candidate, ["--version"], { timeoutMs: 3000, allowFailure: true });
+    if (result.code === 0) return candidate;
+  }
+  return null;
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: root,
+      env: options.env || process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`${command} ${args.join(" ")} timed out after ${options.timeoutMs}ms`));
+    }, options.timeoutMs || 30_000);
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      if (options.allowFailure) resolve({ code: 127, stdout, stderr: `${stderr}${error.message}` });
+      else reject(error);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}

--- a/cli/src/brain-render.ts
+++ b/cli/src/brain-render.ts
@@ -1,5 +1,6 @@
 import type { BrainStreamEvent } from "./brain-client.js";
 import { t } from "./i18n.js";
+import { bold, cyan, dim, green, red, supportsColor, yellow } from "./terminal-style.js";
 import { normalizeUsageTelemetry, renderUsageTelemetry } from "./usage-telemetry.js";
 
 export interface HumanBrainRenderState {
@@ -11,26 +12,29 @@ export function renderBrainEventForHuman(
   state: HumanBrainRenderState,
   stream: NodeJS.WriteStream,
 ): void {
+  const color = supportsColor(stream);
   if (event.type === "provider") {
     state.provider = event.activeProvider;
     const fallback = event.fallbackFrom?.length
       ? ` fallback: ${event.fallbackFrom.map((entry) => `${entry.id}${entry.reason ? `(${entry.reason})` : ""}`).join(" -> ")} -> `
       : "";
-    stream.write(`\nroute: ${fallback}${event.activeProvider}\n`);
+    stream.write(`\n${cyan("◇", color)} ${bold("route", color)}: ${dim(fallback, color)}${event.activeProvider}\n`);
     return;
   }
   if (event.type === "tool_progress") {
     if (event.event === "start") {
-      stream.write(`\nserver tool: ${event.name} ...\n`);
+      stream.write(`\n${cyan("╭─", color)} ${bold("tool", color)} ${event.name}\n${cyan("│", color)} ${dim("running", color)}\n${cyan("╰─", color)}\n`);
       return;
     }
     if (event.event === "end") {
       const status = event.ok === false ? "failed" : "done";
       const timing = typeof event.ms === "number" ? ` ${event.ms}ms` : "";
-      stream.write(`server tool: ${event.name} ${status}${timing}\n`);
+      const icon = event.ok === false ? red("×", color) : green("✓", color);
+      const label = event.ok === false ? red(status, color) : green(status, color);
+      stream.write(`${icon} ${bold("tool", color)} ${event.name} ${label}${dim(timing, color)}\n`);
       return;
     }
-    stream.write(`\nserver tool: ${event.name} ${event.event}\n`);
+    stream.write(`\n${yellow("•", color)} ${bold("tool", color)} ${event.name} ${event.event}\n`);
     return;
   }
   if (event.type === "brain.error") {

--- a/cli/src/commands/chat.ts
+++ b/cli/src/commands/chat.ts
@@ -25,6 +25,7 @@ import { buildMemoryContextFrameSync, handleMemorySlashCommand } from "../sessio
 import { resolveDataDir } from "../session/store.js";
 import { resolveDefaultBrainUrl } from "../brain-url.js";
 import { shouldUseInkTui } from "../terminal-safety.js";
+import { createDecodeSpeedTracker } from "../decode-speed.js";
 
 export const CHAT_SLASH_COMMANDS = [
   "/exit",
@@ -243,6 +244,8 @@ export async function runChat(args: ParsedArgs, options: { intro?: boolean; brai
     const renderReasoning = shouldRenderReasoning(reasoning.display, false);
     const md = new MarkdownStream((s) => output.write(s), supportsColor(output));
     const turnStarted = Date.now();
+    const decodeTracker = createDecodeSpeedTracker(turnStarted);
+    let decodeTps: string | null = null;
     try {
       spinner.start();
       for await (const event of streamBrainChat({ brainUrl, messages, reasoning, fallbackProvider: cliProvider?.profile })) {
@@ -254,6 +257,7 @@ export async function runChat(args: ParsedArgs, options: { intro?: boolean; brai
         }
         if (event.type === "assistant.delta") {
           md.push(event.text);
+          decodeTps = decodeTracker.add(event.text) || decodeTps;
           assistant += event.text;
         } else {
           if (event.type === "usage") latestUsage = summarizeUsage(event.usage, { durationMs: Date.now() - turnStarted });
@@ -276,6 +280,7 @@ export async function runChat(args: ParsedArgs, options: { intro?: boolean; brai
       mode: renderMode(mode),
       reasoning: reasoning.effort,
       usage: latestUsage,
+      decodeTps,
       color: supportsColor(output),
     })}\n\n`);
     return "continue";

--- a/cli/src/commands/chat.ts
+++ b/cli/src/commands/chat.ts
@@ -17,6 +17,7 @@ import { resolveEffectivePermissions } from "../permissions.js";
 import { HistoryNavigator } from "../history.js";
 import { readInteractiveLine } from "../interactive-line.js";
 import { refreshCliRuntimeSystemMessage, resetCliRuntimeMessages } from "../runtime-context.js";
+import { isLocalRuntimeQuestion, localeForText, renderLocalRuntimeAnswer } from "../runtime-answer.js";
 import { modelDisplayName, modelLabelWithId } from "../provider-presets.js";
 import { buildImagesContentParts } from "../media.js";
 import { parseImagePromptCommand, summarizeImageRefs } from "../pasted-context.js";
@@ -29,6 +30,8 @@ export const CHAT_SLASH_COMMANDS = [
   "/exit",
   "/quit",
   "/help",
+  "/version",
+  "/about",
   "/fast",
   "/think",
   "/reasoning",
@@ -101,6 +104,16 @@ export async function runChat(args: ParsedArgs, options: { intro?: boolean; brai
     if (text === "/exit" || text === "/quit") return "break";
     if (text === "/help") {
       output.write(`${t("chat.help")}\n\n`);
+      return "continue";
+    }
+    if (isLocalRuntimeQuestion(text)) {
+      output.write(`${renderLocalRuntimeAnswer({
+        routeLabel: chatRouteLabel(cliProvider?.profile),
+        brainUrl,
+        cwd: chatCwd,
+        mode: renderMode(mode),
+        reasoning: reasoning.effort,
+      }, localeForText(text))}\n\n`);
       return "continue";
     }
     if (text === "/fast") {
@@ -233,7 +246,7 @@ export async function runChat(args: ParsedArgs, options: { intro?: boolean; brai
     try {
       spinner.start();
       for await (const event of streamBrainChat({ brainUrl, messages, reasoning, fallbackProvider: cliProvider?.profile })) {
-        if (event.type === "assistant.delta" || (event.type === "reasoning.delta" && renderReasoning)) {
+        if (eventWritesHumanOutput(event, renderReasoning)) {
           spinner.stop();
         }
         if (event.type === "brain.error") {
@@ -291,6 +304,15 @@ export async function runChat(args: ParsedArgs, options: { intro?: boolean; brai
     rl?.close();
   }
   return 0;
+}
+
+function eventWritesHumanOutput(event: BrainStreamEvent, renderReasoning: boolean): boolean {
+  return event.type === "assistant.delta"
+    || event.type === "provider"
+    || event.type === "tool_progress"
+    || event.type === "brain.error"
+    || event.type === "usage"
+    || (event.type === "reasoning.delta" && renderReasoning);
 }
 
 export interface ChatMode {

--- a/cli/src/commands/code.ts
+++ b/cli/src/commands/code.ts
@@ -37,6 +37,7 @@ import { renderToolLedger, toolLedgerEntry, type ToolLedgerEntry } from "../tool
 import { prepareCodeTaskInput } from "../code-input.js";
 import type { RuntimeInstructionFrame } from "../../../shared/runtime-instruction-frames.js";
 import { resolveDefaultBrainUrl } from "../brain-url.js";
+import { isLocalRuntimeQuestion, localeForText, renderLocalRuntimeAnswer } from "../runtime-answer.js";
 
 const pExecFile = promisify(execFile);
 
@@ -126,6 +127,7 @@ export async function runCode(args: ParsedArgs): Promise<number> {
   const tool = getStringFlag(args.flags, "tool") as ClientToolName | null;
   if (!tool) {
     const task = codeTaskPrompt(args);
+    if (task && isLocalRuntimeQuestion(task)) return runCodeLocalRuntimeAnswer(args, task, json);
     if (task) return runCodeTask(args, task, json);
     if (!json && input.isTTY && output.isTTY) {
       if (shouldUseInkTui(args)) {
@@ -179,6 +181,43 @@ export function codeTaskPrompt(args: ParsedArgs): string {
   ].filter((part): part is string => !!part && !!part.trim()).join("\n\n").trim();
 }
 
+async function runCodeLocalRuntimeAnswer(args: ParsedArgs, task: string, json: boolean): Promise<number> {
+  const mode = await resolveCodeMode(args);
+  const reasoning = parseReasoningOptions(args);
+  const cliProvider = await resolveCliProviderProfile(args);
+  const text = await renderCodeLocalRuntimeAnswer(args, task, mode, reasoning, cliProvider?.profile);
+  if (json) {
+    writeJsonLine({ type: "code.task.started", ts: nowIso(), task, local: true });
+    writeJsonLine({ type: "assistant.delta", ts: nowIso(), text });
+    writeJsonLine({ type: "code.task.finished", ts: nowIso(), ok: true, local: true, contentReturned: true });
+  } else {
+    process.stdout.write(renderAssistantBlock(text, renderCodeFooter({
+      context: { cwd: cwd(args), gitStatus: "unknown", gitDiffStat: "", topFiles: [], packageScripts: {} },
+      mode,
+      mockBrain: false,
+      reasoning,
+      fallbackProvider: cliProvider?.profile,
+    })));
+  }
+  return 0;
+}
+
+async function renderCodeLocalRuntimeAnswer(
+  args: ParsedArgs,
+  text: string,
+  mode: ChatMode,
+  reasoning: ReturnType<typeof parseReasoningOptions>,
+  fallbackProvider?: CliProviderProfile,
+): Promise<string> {
+  return renderLocalRuntimeAnswer({
+    routeLabel: codeRouteLabel(false, fallbackProvider),
+    brainUrl: await resolveDefaultBrainUrl(args),
+    cwd: cwd(args),
+    mode: renderMode(mode),
+    reasoning: reasoning.effort,
+  }, localeForText(text));
+}
+
 export function renderCodeHeadlessHelp(): string {
   const version = readVersionInfo().version || "0.80.0";
   return [
@@ -228,6 +267,8 @@ async function runCodeInteractive(args: ParsedArgs): Promise<number> {
     "/exit",
     "/quit",
     "/help",
+    "/version",
+    "/about",
     "/tools",
     "/fast",
     "/think",
@@ -267,6 +308,10 @@ async function runCodeInteractive(args: ParsedArgs): Promise<number> {
       if (text === "/exit" || text === "/quit") break;
       if (text === "/help") {
         output.write(`${t("code.help")}\n\n`);
+        continue;
+      }
+      if (isLocalRuntimeQuestion(text)) {
+        output.write(`${await renderCodeLocalRuntimeAnswer(args, text, mode, reasoning, cliProvider?.profile)}\n\n`);
         continue;
       }
       if (text === "/tools") {

--- a/cli/src/commands/code.ts
+++ b/cli/src/commands/code.ts
@@ -1511,7 +1511,7 @@ async function collectBrainText(inputData: {
       tools: codeToolDefinitions(),
     })) {
       const renderReasoning = shouldRenderReasoning(inputData.reasoning.display, inputData.json);
-      if (event.type === "assistant.delta" || (event.type === "reasoning.delta" && renderReasoning)) {
+      if (eventWritesHumanOutput(event, renderReasoning, !!inputData.json || !!inputData.onEvent)) {
         spinner.stop();
       }
       if (event.type === "reasoning.delta" && renderReasoning) {
@@ -1559,6 +1559,16 @@ async function collectBrainText(inputData: {
     spinner.stop();
   }
   return { text, usageSummary, usageRecords, toolCalls: streamedToolCalls.toToolCalls() };
+}
+
+function eventWritesHumanOutput(event: BrainStreamEvent, renderReasoning: boolean, structuredOutput: boolean): boolean {
+  if (structuredOutput) return false;
+  return event.type === "assistant.delta"
+    || event.type === "provider"
+    || event.type === "tool_progress"
+    || event.type === "brain.error"
+    || event.type === "usage"
+    || (event.type === "reasoning.delta" && renderReasoning);
 }
 
 export function codeToolDefinitions(): ChatToolDefinition[] {

--- a/cli/src/commands/prompt.ts
+++ b/cli/src/commands/prompt.ts
@@ -9,6 +9,7 @@ import { resolveCliProviderProfile } from "../provider-profile.js";
 import { t } from "../i18n.js";
 import { buildImagesContentParts, parseImageList } from "../media.js";
 import { resetCliRuntimeMessages } from "../runtime-context.js";
+import { isLocalRuntimeQuestion, localeForText, renderLocalRuntimeAnswer } from "../runtime-answer.js";
 import { chatRouteLabel } from "./chat.js";
 import { resolveDefaultBrainUrl } from "../brain-url.js";
 
@@ -48,6 +49,26 @@ export async function runPrompt(args: ParsedArgs, options: PromptOptions = {}): 
 
   if (options.json) {
     writeJsonLine({ type: "run.started", ts: nowIso(), prompt, reasoning, ...(imagePaths.length ? { images: imagePaths } : {}) });
+  }
+
+  if (!imagePaths.length && isLocalRuntimeQuestion(prompt)) {
+    const text = renderLocalRuntimeAnswer({
+      routeLabel: chatRouteLabel(cliProvider?.profile),
+      brainUrl,
+      cwd: process.cwd(),
+      reasoning: reasoning.effort,
+    }, localeForText(prompt));
+    if (options.json) {
+      writeJsonLine({ type: "assistant.delta", ts: nowIso(), text });
+      writeJsonLine({ type: "run.finished", ts: nowIso(), ok: true, local: true });
+    } else {
+      process.stdout.write(`${text}\n`);
+    }
+    if (saveSession) {
+      const savedPath = await appendSessionTurn({ dataDir, sessionPath, cwd: process.cwd(), title, prompt, assistant: text, modelProvider: "lynn-cli", modelId: "local-runtime" });
+      if (options.json) writeJsonLine({ type: "session.saved", ts: nowIso(), path: savedPath });
+    }
+    return 0;
   }
 
   if (options.mockBrain) {
@@ -99,7 +120,7 @@ export async function runPrompt(args: ParsedArgs, options: PromptOptions = {}): 
         fallbackProvider: cliProvider?.profile,
       })) {
         const renderReasoning = shouldRenderReasoning(reasoning.display, !!options.json);
-        if (event.type === "assistant.delta" || (event.type === "reasoning.delta" && renderReasoning)) {
+        if (!options.json && eventWritesHumanOutput(event, renderReasoning)) {
           spinner.stop();
         }
         if (event.type === "brain.error") {
@@ -190,6 +211,15 @@ export async function runPrompt(args: ParsedArgs, options: PromptOptions = {}): 
     process.stdout.write("\n");
   }
   return 0;
+}
+
+function eventWritesHumanOutput(event: BrainStreamEvent, renderReasoning: boolean): boolean {
+  return event.type === "assistant.delta"
+    || event.type === "provider"
+    || event.type === "tool_progress"
+    || event.type === "brain.error"
+    || event.type === "usage"
+    || (event.type === "reasoning.delta" && renderReasoning);
 }
 
 function promptImagePaths(args: ParsedArgs): string[] {

--- a/cli/src/commands/vision.ts
+++ b/cli/src/commands/vision.ts
@@ -49,7 +49,7 @@ export async function runVisionCommand(args: ParsedArgs, command: VisionCommand,
       fallbackProvider: cliProvider?.profile,
     })) {
       const renderReasoning = shouldRenderReasoning(reasoning.display, json);
-      if (event.type === "assistant.delta" || (event.type === "reasoning.delta" && renderReasoning)) spinner.stop();
+      if (!json && eventWritesHumanOutput(event, renderReasoning)) spinner.stop();
       if (event.type === "brain.error") {
         if (json) renderVisionEvent(event, { json, renderReasoning, renderState, startedAt });
         throw new Error(formatBrainErrorForHuman(event.error, event.code));
@@ -73,6 +73,15 @@ export async function runVisionCommand(args: ParsedArgs, command: VisionCommand,
     process.stdout.write("\n");
   }
   return 0;
+}
+
+function eventWritesHumanOutput(event: BrainStreamEvent, renderReasoning: boolean): boolean {
+  return event.type === "assistant.delta"
+    || event.type === "provider"
+    || event.type === "tool_progress"
+    || event.type === "brain.error"
+    || event.type === "usage"
+    || (event.type === "reasoning.delta" && renderReasoning);
 }
 
 function resolveVisionInput(args: ParsedArgs): { imagePaths: string[]; userText: string } {

--- a/cli/src/i18n.ts
+++ b/cli/src/i18n.ts
@@ -86,6 +86,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     "chat.help":
       "/exit 退出聊天\n" +
       "/clear 清空上下文\n" +
+      "/version 查看 Lynn CLI 本地版本和当前 Brain 路由\n" +
       "/model 查看 Brain 三段模型路由; /model stepfun|mimo|spark 切换 StepFun 3.7 Flash / MiMo V2.5 Pro / Spark Qwen 3.6 35B A3B\n" +
       "/memory 查看长期记忆; /memory add <事实> 保存长期事实; /memory forget <id> 删除\n" +
       "/cwd 查看工作目录;默认是启动 Lynn 时终端所在目录,可先 cd 或用 --cwd 指定\n" +
@@ -135,6 +136,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
       "/resume [last|session.jsonl] [说明] 继续上次长任务\n" +
       "/memory 查看长期记忆; /memory add <事实> 保存长期事实; /memory forget <id> 删除\n" +
       "/cwd 查看工作目录;默认是启动 Lynn 时终端所在目录,可先 cd 或用 --cwd 指定\n" +
+      "/version 查看 Lynn CLI 本地版本和当前 Brain 路由\n" +
       "/model 查看 Brain 三段模型路由; /model stepfun|mimo|spark 切换 StepFun 3.7 Flash / MiMo V2.5 Pro / Spark Qwen 3.6 35B A3B\n" +
       "/setup 打开 CLI-only BYOK 三步向导\n" +
       "/providers 查看提供方和 BYOK 设置\n" +
@@ -351,6 +353,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     "chat.help":
       "/exit leave chat\n" +
       "/clear reset context\n" +
+      "/version show the local Lynn CLI version and current Brain route\n" +
       "/model show the three Brain model choices; /model stepfun|mimo|spark switches StepFun 3.7 Flash / MiMo V2.5 Pro / Spark Qwen 3.6 35B A3B\n" +
       "/memory show durable memory; /memory add <fact> save a durable fact; /memory forget <id> delete\n" +
       "/cwd show working directory; default is the terminal directory where Lynn started, use cd or --cwd to change\n" +
@@ -400,6 +403,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
       "/resume [last|session.jsonl] [note] continue a saved long task\n" +
       "/memory show durable memory; /memory add <fact> save a durable fact; /memory forget <id> delete\n" +
       "/cwd show working directory; default is the terminal directory where Lynn started, use cd or --cwd to change\n" +
+      "/version show the local Lynn CLI version and current Brain route\n" +
       "/model show the three Brain model choices; /model stepfun|mimo|spark switches StepFun 3.7 Flash / MiMo V2.5 Pro / Spark Qwen 3.6 35B A3B\n" +
       "/setup open the CLI-only BYOK three-step wizard\n" +
       "/providers show provider and BYOK setup\n" +

--- a/cli/src/ink-chat.ts
+++ b/cli/src/ink-chat.ts
@@ -18,6 +18,7 @@ import { InkMarkdown } from "./ink-markdown.js";
 import { handleInkProviderCommand } from "./ink-provider-commands.js";
 import { InkInputLine } from "./ink-input-line.js";
 import { refreshCliRuntimeSystemMessage, resetCliRuntimeMessages } from "./runtime-context.js";
+import { isLocalRuntimeQuestion, localeForText, renderLocalRuntimeAnswer } from "./runtime-answer.js";
 import { analyzePastedContext, appendPastedText, parseImagePromptCommand, summarizeImageRefs, summarizePastedContext } from "./pasted-context.js";
 import { buildImagesContentParts } from "./media.js";
 import { buildMemoryContextFrameSync, handleMemorySlashCommand } from "./session/memory.js";
@@ -370,6 +371,27 @@ async function submitInput(inputData: {
   }
   if (text === "/help") {
     inputData.setTurns((current) => [...current, { id: Date.now(), role: "system", text: t("chat.help") }]);
+    return;
+  }
+  if (isLocalRuntimeQuestion(text)) {
+    const answer = renderLocalRuntimeAnswer({
+      routeLabel: chatRouteLabel(inputData.fallbackProvider),
+      brainUrl: inputData.props.brainUrl,
+      cwd: inputData.cwd,
+      mode: renderMode(inputData.mode),
+      reasoning: inputData.reasoning.effort,
+    }, localeForText(text));
+    if (text.startsWith("/")) {
+      inputData.setTurns((current) => [...current, { id: Date.now(), role: "system", text: answer }]);
+      return;
+    }
+    inputData.messages.push({ role: "user", content: text }, { role: "assistant", content: answer });
+    const userId = Date.now();
+    inputData.setTurns((current) => [
+      ...current,
+      { id: userId, role: "user", text },
+      { id: userId + 1, role: "assistant", text: answer },
+    ]);
     return;
   }
   if (text === "/clear") {

--- a/cli/src/interactive-line.ts
+++ b/cli/src/interactive-line.ts
@@ -4,6 +4,7 @@ import { completeSlash } from "./completion.js";
 import { HistoryNavigator } from "./history.js";
 import { renderInputBand } from "./tui-input.js";
 import { supportsColor } from "./terminal-style.js";
+import { terminalTuiProfile } from "./terminal-safety.js";
 
 export interface InteractiveLineMode {
   approval: "ask" | "on-failure" | "never" | "yolo";
@@ -29,6 +30,9 @@ export async function readInteractiveLine(
     } finally {
       rl.close();
     }
+  }
+  if (shouldUseNativeLineInput()) {
+    return readNativeTerminalLine(prompt, options);
   }
 
   const rawBefore = input.isRaw;
@@ -112,4 +116,34 @@ export async function readInteractiveLine(
     };
     input.on("data", onData);
   });
+}
+
+export function shouldUseNativeLineInput(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.LYNN_CLI_APPLE_TERMINAL_RAW_INPUT === "1") return false;
+  const profile = terminalTuiProfile(env);
+  return profile.appleTerminal && !profile.animation;
+}
+
+async function readNativeTerminalLine(prompt: string, options: InteractiveLineOptions): Promise<string | null> {
+  const width = Math.max(80, typeof output.columns === "number" ? output.columns : 0);
+  const color = supportsColor(output);
+  output.write(`${renderInputBand({ prompt: "", value: "", width, color })}\r`);
+  const rl = readline.createInterface({
+    input,
+    output,
+    terminal: true,
+    completer: options.completions
+      ? (line: string) => {
+          const completion = completeSlash(line, options.completions || []);
+          return [completion.matches.length ? completion.matches : [], line] as [string[], string];
+        }
+      : undefined,
+  });
+  try {
+    return await rl.question(prompt);
+  } catch {
+    return null;
+  } finally {
+    rl.close();
+  }
 }

--- a/cli/src/runtime-answer.ts
+++ b/cli/src/runtime-answer.ts
@@ -11,13 +11,16 @@ export interface RuntimeAnswerContext {
 
 const VERSION_PATTERNS = [
   /(^|\s)\/(?:version|about)(\s|$)/i,
-  /(?:lynn\s*)?(?:cli\s*)?(?:版本号|version|about)/i,
-  /(?:你|当前|现在).{0,8}(?:版本|version)/i,
+  /(?:lynn\s*)?(?:cli\s*)?(?:版本号|about)/i,
+  /(?:lynn|cli|命令行|本地).{0,8}版本/i,
+  /(?:你|当前|现在|本地|运行时|命令行|cli).{0,12}(?:版本|版本号|version)/i,
+  /\b(?:what|which|show|tell|current|your|runtime|cli|lynn)\b.{0,28}\b(?:version|about)\b/i,
 ];
 
 export function isLocalRuntimeQuestion(text: string): boolean {
   const value = text.trim();
   if (!value) return false;
+  if (/^(?:version|about)$/i.test(value)) return true;
   return VERSION_PATTERNS.some((pattern) => pattern.test(value));
 }
 

--- a/cli/src/runtime-answer.ts
+++ b/cli/src/runtime-answer.ts
@@ -1,0 +1,53 @@
+import { readVersionInfo } from "./version.js";
+import { displayCwd } from "./startup.js";
+
+export interface RuntimeAnswerContext {
+  routeLabel: string;
+  brainUrl: string;
+  cwd: string;
+  mode?: string;
+  reasoning?: string;
+}
+
+const VERSION_PATTERNS = [
+  /(^|\s)\/(?:version|about)(\s|$)/i,
+  /(?:lynn\s*)?(?:cli\s*)?(?:版本号|version|about)/i,
+  /(?:你|当前|现在).{0,8}(?:版本|version)/i,
+];
+
+export function isLocalRuntimeQuestion(text: string): boolean {
+  const value = text.trim();
+  if (!value) return false;
+  return VERSION_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+export function renderLocalRuntimeAnswer(input: RuntimeAnswerContext, locale: "zh" | "en" = "zh"): string {
+  const version = readVersionInfo();
+  const build = version.build ? ` (${version.build})` : "";
+  if (locale === "en") {
+    return [
+      `Lynn CLI version: ${version.version}${build}`,
+      `Runtime route: ${input.routeLabel}`,
+      `Brain: ${input.brainUrl}`,
+      `Directory: ${displayCwd(input.cwd)}`,
+      input.mode ? `Permissions: ${input.mode}` : "",
+      input.reasoning ? `Reasoning: ${input.reasoning}` : "",
+      "",
+    "Use `Lynn version` for the local CLI version, `/model` for the Brain model route, and `Lynn providers` for BYOK settings.",
+    ].filter(Boolean).join("\n");
+  }
+  return [
+    `Lynn CLI 版本:${version.version}${build}`,
+    `模型路由:${input.routeLabel}`,
+    `Brain:${input.brainUrl}`,
+    `目录:${displayCwd(input.cwd)}`,
+    input.mode ? `权限:${input.mode}` : "",
+    input.reasoning ? `思考:${input.reasoning}` : "",
+    "",
+    "提示:`Lynn version` 查看本地 CLI 版本,`/model` 查看 Brain 模型路由,`Lynn providers` 查看 BYOK 设置。",
+  ].filter(Boolean).join("\n");
+}
+
+export function localeForText(text: string): "zh" | "en" {
+  return /[\u3400-\u9fff]/.test(text) ? "zh" : "en";
+}

--- a/cli/src/runtime-context.ts
+++ b/cli/src/runtime-context.ts
@@ -1,12 +1,16 @@
 import type { ChatMessage } from "./brain-client.js";
+import { readVersionInfo } from "./version.js";
 
 export function buildCliRuntimeSystemMessage(routeLabel: string, memoryFrame = ""): ChatMessage {
+  const version = readVersionInfo();
+  const build = version.build ? ` (${version.build})` : "";
   return {
     role: "system",
     content: [
       "You are Lynn CLI, the terminal interface for Lynn.",
+      `Current Lynn CLI version: ${version.version}${build}.`,
       `Current model route shown to the user: ${routeLabel}.`,
-      "If the user asks which model, route, or runtime you are using, answer from this runtime context instead of saying the model is unknown.",
+      "If the user asks which model, route, CLI version, or runtime you are using, answer from this runtime context instead of saying the model is unknown or that Lynn CLI has no independent version.",
       "The default online route is StepFun 3.7 Flash first (256K context; high reasoning with a 32K reasoning/generation budget) through the local Lynn Brain router, with MiMo V2.5 Pro as the multimodal/native-search fallback and Spark Qwen 3.6 35B A3B as the local third fallback.",
       "StepFun 3.7 Flash is the text/coding head route. MiMo V2.5 Pro owns image/audio/video and native search fallback.",
       "The user can change CLI-only BYOK with /model, /providers, or /setup; those slash commands are handled by Lynn locally.",

--- a/cli/src/terminal-spinner.ts
+++ b/cli/src/terminal-spinner.ts
@@ -1,6 +1,7 @@
 import { brightCyan, cyan, dim, supportsColor } from "./terminal-style.js";
 import { t } from "./i18n.js";
 import { visibleLength } from "./startup.js";
+import { terminalTuiProfile } from "./terminal-safety.js";
 
 export function renderSweepFrame(width: number, frame: number, color: boolean): string {
   const safeWidth = Math.max(8, width);
@@ -42,6 +43,7 @@ export class TerminalSpinner {
     if (this.active || !this.stream.isTTY) return;
     this.active = true;
     this.render();
+    if (!terminalTuiProfile().animation) return;
     this.timer = setInterval(() => this.render(), 90);
   }
 

--- a/cli/tests/brain-render.test.ts
+++ b/cli/tests/brain-render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatBrainErrorForHuman, summarizeUsage } from "../src/brain-render.js";
+import { formatBrainErrorForHuman, renderBrainEventForHuman, summarizeUsage, type HumanBrainRenderState } from "../src/brain-render.js";
 
 describe("brain render usage summary", () => {
   it("shows tokens, cache hit ratio, and TPS when usage timing is available", () => {
@@ -41,5 +41,28 @@ describe("formatBrainErrorForHuman", () => {
     const text = formatBrainErrorForHuman("all providers failed");
     expect(text).toContain("provider");
     expect(text).toContain("Lynn providers set --preset stepfun");
+  });
+});
+
+describe("renderBrainEventForHuman", () => {
+  it("renders route and tool progress as stable cards", () => {
+    let output = "";
+    const stream = {
+      isTTY: false,
+      write(chunk: string) {
+        output += chunk;
+        return true;
+      },
+    } as unknown as NodeJS.WriteStream;
+    const state: HumanBrainRenderState = {};
+
+    renderBrainEventForHuman({ type: "provider", activeProvider: "step-3.7-flash" }, state, stream);
+    renderBrainEventForHuman({ type: "tool_progress", event: "start", name: "web_search" }, state, stream);
+    renderBrainEventForHuman({ type: "tool_progress", event: "end", name: "web_search", ok: true, ms: 5134 }, state, stream);
+
+    expect(output).toContain("route: step-3.7-flash");
+    expect(output).toContain("╭─ tool web_search");
+    expect(output).toContain("✓ tool web_search done 5134ms");
+    expect(output).not.toContain("server tool:");
   });
 });

--- a/cli/tests/code-tools.test.ts
+++ b/cli/tests/code-tools.test.ts
@@ -516,6 +516,31 @@ describe("code tools", () => {
     expect(output).toContain("code.tools");
   });
 
+  it("answers code headless version questions locally", async () => {
+    const original = process.stdout.write;
+    let output = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      output += String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await expect(runCode(parseArgs([
+        "code",
+        "-p",
+        "你的版本号",
+        "--json",
+        "--brain-url",
+        "http://127.0.0.1:1",
+      ]))).resolves.toBe(0);
+    } finally {
+      process.stdout.write = original;
+    }
+    expect(output).toContain("\"type\":\"assistant.delta\"");
+    expect(output).toContain("Lynn CLI 版本");
+    expect(output).toContain("\"local\":true");
+    expect(output).not.toContain("fetch failed");
+  });
+
   it("renders an interactive code-mode intro with full model route and permission mode", () => {
     const intro = renderCodeIntro({ approval: "ask", sandbox: "workspace-write" });
 

--- a/cli/tests/prompt.test.ts
+++ b/cli/tests/prompt.test.ts
@@ -23,6 +23,30 @@ describe("prompt stdin handling", () => {
     expect(mergePromptAndStdin("", "hello")).toBe("hello");
   });
 
+  it("answers local CLI version questions without contacting Brain", async () => {
+    const original = process.stdout.write;
+    let output = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      output += String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await expect(runPrompt(parseArgs([
+        "-p",
+        "你的版本号",
+        "--json",
+        "--brain-url",
+        "http://127.0.0.1:1",
+      ]), { json: true })).resolves.toBe(0);
+    } finally {
+      process.stdout.write = original;
+    }
+
+    expect(output).toContain("\"type\":\"assistant.delta\"");
+    expect(output).toContain("Lynn CLI 版本");
+    expect(output).toContain("\"local\":true");
+  });
+
   it("runs prompt mode through CLI BYOK when local Brain is offline", async () => {
     const provider = http.createServer((request, response) => {
       expect(request.url).toBe("/v1/chat/completions");

--- a/cli/tests/runtime-answer.test.ts
+++ b/cli/tests/runtime-answer.test.ts
@@ -8,6 +8,8 @@ describe("runtime answer", () => {
     expect(isLocalRuntimeQuestion("你的版本号")).toBe(true);
     expect(isLocalRuntimeQuestion("what version are you?")).toBe(true);
     expect(isLocalRuntimeQuestion("帮我写一个版本比较函数")).toBe(false);
+    expect(isLocalRuntimeQuestion("bump the package version in package.json")).toBe(false);
+    expect(isLocalRuntimeQuestion("write a semantic version comparator")).toBe(false);
   });
 
   it("renders the local CLI version instead of asking the model", () => {

--- a/cli/tests/runtime-answer.test.ts
+++ b/cli/tests/runtime-answer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { isLocalRuntimeQuestion, localeForText, renderLocalRuntimeAnswer } from "../src/runtime-answer.js";
+
+describe("runtime answer", () => {
+  it("detects local version and about questions", () => {
+    expect(isLocalRuntimeQuestion("/version")).toBe(true);
+    expect(isLocalRuntimeQuestion("/about")).toBe(true);
+    expect(isLocalRuntimeQuestion("你的版本号")).toBe(true);
+    expect(isLocalRuntimeQuestion("what version are you?")).toBe(true);
+    expect(isLocalRuntimeQuestion("帮我写一个版本比较函数")).toBe(false);
+  });
+
+  it("renders the local CLI version instead of asking the model", () => {
+    const text = renderLocalRuntimeAnswer({
+      routeLabel: "StepFun 3.7 Flash → MiMo V2.5 Pro",
+      brainUrl: "https://api.merkyorlynn.com/api/v2",
+      cwd: "/tmp/project",
+      mode: "ask / workspace-write",
+      reasoning: "high",
+    }, "zh");
+    expect(text).toContain("Lynn CLI 版本:");
+    expect(text).toContain("模型路由:StepFun 3.7 Flash");
+    expect(text).toContain("Brain:https://api.merkyorlynn.com/api/v2");
+    expect(text).toContain("权限:ask / workspace-write");
+  });
+
+  it("uses English for English prompts", () => {
+    expect(localeForText("what version are you?")).toBe("en");
+    expect(localeForText("你的版本号")).toBe("zh");
+  });
+});

--- a/cli/tests/tui-input.test.ts
+++ b/cli/tests/tui-input.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { readInteractiveLine } from "../src/interactive-line.js";
+import { readInteractiveLine, shouldUseNativeLineInput } from "../src/interactive-line.js";
 import { renderInputBand } from "../src/tui-input.js";
 import { visibleLength } from "../src/startup.js";
 
@@ -24,5 +24,11 @@ describe("renderInputBand", () => {
 describe("readInteractiveLine", () => {
   it("exports the shared input reader used by chat and code modes", () => {
     expect(typeof readInteractiveLine).toBe("function");
+  });
+
+  it("uses native line input for Apple Terminal stable mode", () => {
+    expect(shouldUseNativeLineInput({ TERM_PROGRAM: "Apple_Terminal" })).toBe(true);
+    expect(shouldUseNativeLineInput({ TERM_PROGRAM: "Apple_Terminal", LYNN_CLI_APPLE_TERMINAL_RAW_INPUT: "1" })).toBe(false);
+    expect(shouldUseNativeLineInput({ TERM_PROGRAM: "iTerm.app" })).toBe(false);
   });
 });

--- a/scripts/cli-install-smoke.mjs
+++ b/scripts/cli-install-smoke.mjs
@@ -165,6 +165,17 @@ try {
   assertIncludes(mock.name, mock.stdout, "你好");
   assertNotIncludes(mock.name, mock.stdout, "Cannot find module");
 
+  const localRuntime = await run("Lynn local runtime answer", lynnBin, ["-p", "你的版本号", "--json", "--brain-url", "http://127.0.0.1:1"], { cwd: installDir, env: { LYNN_DATA_DIR: dataDir } });
+  assertIncludes(localRuntime.name, localRuntime.stdout, "\"local\":true");
+  assertIncludes(localRuntime.name, localRuntime.stdout, "Lynn CLI 版本");
+  assertIncludes(localRuntime.name, localRuntime.stdout, "0.80.3");
+  assertNotIncludes(localRuntime.name, localRuntime.stdout + localRuntime.stderr, "fetch failed");
+
+  const nonRuntime = await run("Lynn non-version prompt", lynnBin, ["-p", "write a semantic version comparator", "--mock-brain", "--json", "--brain-url", "http://127.0.0.1:1"], { cwd: installDir, env: { LYNN_DATA_DIR: dataDir } });
+  assertIncludes(nonRuntime.name, nonRuntime.stdout, "semantic version comparator");
+  assertNotIncludes(nonRuntime.name, nonRuntime.stdout, "\"local\":true");
+  assertNotIncludes(nonRuntime.name, nonRuntime.stdout, "Lynn CLI 版本");
+
   const tools = await run("Lynn code list tools", lynnBin, ["code", "--list-tools"], { cwd: installDir, env: { LYNN_DATA_DIR: dataDir } });
   assertIncludes(tools.name, tools.stdout, "read_file");
   assertIncludes(tools.name, tools.stdout, "apply_patch");


### PR DESCRIPTION
## Summary
- default Apple Terminal to the stable renderer path and keep spinner/rendering from interleaving with human output
- answer local CLI version/runtime questions locally in chat, prompt, and code mode
- tighten runtime-question detection so normal version-related coding tasks still go to the model
- keep decode TPS visible in the stable renderer status line
- extend CLI stress gates for Apple Terminal Chinese input, /think, /reasoning, /yolo, /help, packaged install behavior, and non-version prompt interception

## Local gates
- npm --prefix cli run typecheck
- npm --prefix cli test -- --reporter=dot (399 tests)
- npm --prefix cli run stress:cli
- npm run test:cli-install

## Notes
- Apple Terminal crash mitigation uses the stable native-line renderer by default; raw input remains opt-in via LYNN_CLI_APPLE_TERMINAL_RAW_INPUT=1.
- CLI package smoke must run from cli/; the install smoke now verifies the correct packaged @lynn/cli tarball behavior.