### PR TITLE
test(cli): include stress gate in release preflight

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:release:nightly": "node scripts/run-release-regression.mjs --mode all --level nightly",
     "test:release:ui": "node --import tsx scripts/run-electron-ui-smoke.ts",
     "release:gate": "node scripts/release-gate.mjs",
-    "release:preflight": "npm test && npm run test:brain-v2 && npm run typecheck && npm run typecheck:runtime && npm run test:cli && npm run test:cli-install && npm run test:cli-fleet && npm run build:server && npm run build:main && npm run build:renderer && npm run test:release:static && npm run test:release:ui",
+    "release:preflight": "npm test && npm run test:brain-v2 && npm run typecheck && npm run typecheck:runtime && npm run test:cli && npm run test:cli-install && npm --prefix cli run stress:cli && npm run test:cli-fleet && npm run build:server && npm run build:main && npm run build:renderer && npm run test:release:static && npm run test:release:ui",
     "build:server": "node scripts/build-server.mjs",
     "build:server:win": "node scripts/build-server.mjs win32 x64",
     "release:manifest": "node --import tsx scripts/generate-update-manifest.ts",


### PR DESCRIPTION
## Summary
- add the v0.80.3 CLI stress gate to `release:preflight` so release runs include `-p`, `code -p`, non-version prompt, and Apple Terminal stable-renderer pressure checks

## Local verification
- `LYNN_CLI_STRESS_SERIAL=8 LYNN_CLI_STRESS_PARALLEL=2 LYNN_CLI_STRESS_APPLE_TURNS=12 npm --prefix cli run stress:cli`
- `npm --prefix cli run typecheck`
- `npm --prefix cli test -- --reporter=dot`
- `npm run test:cli-install`

## Note
- I also prepared a CI workflow step, but the current GitHub token cannot push `.github/workflows/*` without `workflow` scope. This PR keeps the release gate enforced without requiring that permission.