### PR TITLE
release(cli): align v0.80.3 docs and static gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://github.com/MerkyorLynn/Lynn/releases"><img src="https://img.shields.io/badge/App-0.80.1-brightgreen" alt="App Version"></a>
-  <a href="https://github.com/MerkyorLynn/Lynn/releases"><img src="https://img.shields.io/badge/CLI-0.80.2-7bcad3" alt="CLI Version"></a>
+  <a href="https://github.com/MerkyorLynn/Lynn/releases"><img src="https://img.shields.io/badge/CLI-0.80.3-7bcad3" alt="CLI Version"></a>
   <a href="https://github.com/MerkyorLynn/Lynn/stargazers"><img src="https://img.shields.io/github/stars/MerkyorLynn/Lynn?style=social" alt="Stars"></a>
   <a href="https://github.com/MerkyorLynn/Lynn/releases"><img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows-lightgrey.svg" alt="Platform"></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.9-3178c6?logo=typescript" alt="TypeScript"></a>
@@ -51,12 +51,12 @@ V0.80 的 CLI 是 Lynn 的终端版:跑在命令行里的 AI 编码助手,带 In
 # Windows: winget install OpenJS.NodeJS.LTS
 
 # 2. Install or update from the Lynn mirror. --force is safe for first install too.
-npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.2-apple-terminal-stable.tgz"
+npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.3.tgz"
 
 # 3. Launch.
 Lynn            # interactive chat TUI
 Lynn code       # coding-agent TUI
-Lynn --version  # should print 0.80.2
+Lynn --version  # should print 0.80.3
 Lynn agents     # copyable headless/Fleet commands for other agents
 ```
 
@@ -115,7 +115,7 @@ Lynn 现在不只是桌面端 Agent。配套的模型、量化和自研推理引
 ## 🆕 近期更新
 
 <details>
-<summary><strong>CLI v0.80.2</strong> · 2026-05-31 · Apple Terminal 稳定性 + TUI 体验热修 <em>(CLI 最新)</em></summary>
+<summary><strong>CLI v0.80.3</strong> · 2026-05-31 · Apple Terminal 稳定性 + TUI 体验热修 <em>(CLI 最新)</em></summary>
 
 **CLI-only 热修,GUI 仍为 v0.80.1**:
 - 🧯 **Apple Terminal / 中文输入稳定性**:保留 Ink TUI、输入框、状态栏和 decode TPS,但在 Apple Terminal 自动关闭高频流光、扫描动画、动态 placeholder 与内联图片转义,规避 macOS Terminal + IME 绘制崩溃。
@@ -124,10 +124,10 @@ Lynn 现在不只是桌面端 Agent。配套的模型、量化和自研推理引
 - 🌐 **纯 CLI 可直接使用**:全新机器只安装 CLI 时,默认走 Lynn 远端 Brain;本地 Brain 或 GUI 可选,BYOK 仍可用。
 
 ```bash
-npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.2-apple-terminal-stable.tgz"
+npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.3.tgz"
 ```
 
-[完整 Release Notes →](https://github.com/MerkyorLynn/Lynn/releases/tag/v0.80.2)
+[完整 Release Notes →](https://github.com/MerkyorLynn/Lynn/releases/tag/v0.80.3)
 
 </details>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -41,7 +41,7 @@ Cursor solves "I am editing this piece of code." Claude Code / Codex CLI solve "
 # Windows: winget install OpenJS.NodeJS.LTS
 
 # 2. Install or update from the Lynn mirror.
-npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.2-apple-terminal-stable.tgz"
+npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.3.tgz"
 
 # 3. Launch.
 Lynn          # interactive chat TUI
@@ -82,7 +82,7 @@ Related repositories:
 ## 🆕 Recent Updates
 
 <details>
-<summary><strong>CLI v0.80.2</strong> · 2026-05-31 · Apple Terminal stability + TUI UX hotfix <em>(CLI latest)</em></summary>
+<summary><strong>CLI v0.80.3</strong> · 2026-05-31 · Apple Terminal stability + TUI UX hotfix <em>(CLI latest)</em></summary>
 
 **CLI-only hotfix; the desktop app remains v0.80.1**:
 - **Apple Terminal / Chinese IME stability**: Lynn keeps the Ink TUI, input box, status bar, and decode TPS, while Apple Terminal uses a conservative profile with high-frequency shimmer/sweep, rotating placeholders, and inline image escapes disabled.
@@ -91,10 +91,10 @@ Related repositories:
 - **Fresh CLI installs can chat**: a standalone CLI install uses the hosted Lynn Brain by default; the desktop app, local Brain, and BYOK remain optional.
 
 ```bash
-npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.2-apple-terminal-stable.tgz"
+npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.3.tgz"
 ```
 
-[Full Release Notes →](https://github.com/MerkyorLynn/Lynn/releases/tag/v0.80.2)
+[Full Release Notes →](https://github.com/MerkyorLynn/Lynn/releases/tag/v0.80.3)
 
 </details>
 
@@ -118,7 +118,7 @@ npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-
 **Lynn's programming-focused release**:
 - **Lynn CLI / Lynn Code**:new `@lynn/cli` package with Ink TUI, markdown/code rendering, real diff preview, multimodal input, `Lynn code -p ... --json`, and `Lynn agents`.
 - **GUI Worker Fleet**:fan-out tasks to multiple CLI workers, inspect logs/diffs/tests/gates, and perform gated merges.
-- **Brain V2 route**:StepFun 3.7 Flash high+32K → MiMo V2.5 Pro/Omni → Spark Qwen 3.6 35B A3B.
+- **Brain V2 route**:StepFun 3.7 Flash (high reasoning + 32K reasoning/generation budget) → MiMo V2.5 Pro/Omni → Spark Qwen 3.6 35B A3B.
 - **Long-run stability**:tool-result reinforcement, chain-tool hints, tool-storm guard, session checkpointing, frame repair, git snapshots, and stable context layers.
 - **Local 9B opt-in**:Qwen3.5-9B MTP no longer auto-starts on app launch; users explicitly enable it when they want local inference.
 - **Release gates**:CLI install docs, mirror tarball, packaged CLI runtime, and headless agent contract are part of the release checks.

--- a/cli/README.md
+++ b/cli/README.md
@@ -28,7 +28,7 @@ winget install OpenJS.NodeJS.LTS
 Install from the Lynn Tencent mirror:
 
 ```bash
-npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.2-apple-terminal-stable.tgz"
+npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.3.tgz"
 ```
 
 The package installs the `Lynn` command. If you installed an older preview that
@@ -47,7 +47,7 @@ If npm dependency downloads are slow in mainland China, keep the Lynn tarball UR
 as-is and add a registry mirror for third-party dependencies:
 
 ```bash
-npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.2-apple-terminal-stable.tgz" \
+npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.3.tgz" \
   --registry=https://registry.npmmirror.com
 ```
 
@@ -55,7 +55,7 @@ Release maintainers can smoke-test the exact CDN tarball before inviting
 external testers:
 
 ```bash
-LYNN_CLI_TARBALL_URL="https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.2-apple-terminal-stable.tgz" \
+LYNN_CLI_TARBALL_URL="https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.3.tgz" \
   npm run test:cli-install:remote
 ```
 
@@ -145,7 +145,7 @@ Agent quick contract:
 # Requires Node.js 20 LTS or 22 LTS with npm.
 
 # Install/update.
-npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.2-apple-terminal-stable.tgz"
+npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.3.tgz"
 
 # Human launch commands.
 Lynn

--- a/docs/ops/v080-cli-install-release-snippet.md
+++ b/docs/ops/v080-cli-install-release-snippet.md
@@ -13,7 +13,7 @@ for other coding agents to parse.
 # Windows: winget install OpenJS.NodeJS.LTS
 
 # 2. Install or update Lynn CLI from the CDN.
-npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.2-apple-terminal-stable.tgz"
+npm install -g --force "https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.3.tgz"
 
 # 3. Launch.
 Lynn          # interactive chat TUI

--- a/scripts/run-release-regression.mjs
+++ b/scripts/run-release-regression.mjs
@@ -117,6 +117,7 @@ async function runStaticChecks({ level }) {
   const pkg = JSON.parse(await fs.readFile(path.join(ROOT, "package.json"), "utf8"));
   const version = pkg.version;
   const cliPkg = JSON.parse(await fs.readFile(path.join(ROOT, "cli", "package.json"), "utf8"));
+  const cliVersion = cliPkg.version || "";
 
   const requiredScripts = [
     "test",
@@ -155,17 +156,18 @@ async function runStaticChecks({ level }) {
     Boolean(pkg.scripts?.["release:preflight"]
       && pkg.scripts["release:preflight"].includes("test:cli")
       && pkg.scripts["release:preflight"].includes("test:cli-install")
+      && pkg.scripts["release:preflight"].includes("stress:cli")
       && pkg.scripts["release:preflight"].includes("test:cli-fleet")),
-    "release:preflight runs CLI smoke, install, and Fleet gates",
+    "release:preflight runs CLI smoke, install, stress, and Fleet gates",
     String(pkg.scripts?.["release:preflight"] || ""),
   ));
 
   checks.push(makeCheck(
-    "static-cli-version-sync",
+    "static-cli-version-valid",
     "blocker",
-    cliPkg.version === version,
-    `cli/package.json version equals package version ${version}`,
-    cliPkg.version ? `cli=${cliPkg.version}` : "missing cli version",
+    /^\d+\.\d+\.\d+$/.test(cliVersion),
+    "cli/package.json has an independent semver version",
+    cliVersion ? `cli=${cliVersion}; app=${version}` : "missing cli version",
   ));
   checks.push(makeCheck(
     "static-cli-package-bin",
@@ -260,12 +262,12 @@ async function runStaticChecks({ level }) {
       `${rel} does not send binary downloads to GitHub`,
       githubBinaryLinks.join("\n"),
     ));
-    const staleVersions = findSemverRefs(text).filter((ref) => ref !== version);
+    const staleVersions = findSemverRefs(text).filter((ref) => ref !== version && ref !== cliVersion);
     checks.push(makeCheck(
       `static-site-${rel}-current-version`,
       "blocker",
       staleVersions.length === 0,
-      `${rel} only references current package version ${version}`,
+      `${rel} only references current app version ${version} or CLI version ${cliVersion}`,
       staleVersions.join(", "),
     ));
   }
@@ -299,13 +301,27 @@ async function runStaticChecks({ level }) {
     releaseNotes.includes(version),
     `README.md mentions current package version ${version}`,
   ));
-  const readmeBadgeVersion = releaseNotes.match(/img\.shields\.io\/badge\/version-([0-9]+\.[0-9]+\.[0-9]+)-/i)?.[1] || "";
   checks.push(makeCheck(
-    "static-readme-version-badge",
+    "static-readme-cli-version",
     "critical",
-    readmeBadgeVersion === version,
-    `README.md version badge equals package version ${version}`,
-    readmeBadgeVersion ? `badge=${readmeBadgeVersion}` : "badge not found",
+    releaseNotes.includes(cliVersion),
+    `README.md mentions current CLI version ${cliVersion}`,
+  ));
+  const readmeAppBadgeVersion = releaseNotes.match(/img\.shields\.io\/badge\/App-([0-9]+\.[0-9]+\.[0-9]+)-/i)?.[1] || "";
+  checks.push(makeCheck(
+    "static-readme-app-version-badge",
+    "critical",
+    readmeAppBadgeVersion === version,
+    `README.md App badge equals package version ${version}`,
+    readmeAppBadgeVersion ? `badge=${readmeAppBadgeVersion}` : "App badge not found",
+  ));
+  const readmeCliBadgeVersion = releaseNotes.match(/img\.shields\.io\/badge\/CLI-([0-9]+\.[0-9]+\.[0-9]+)-/i)?.[1] || "";
+  checks.push(makeCheck(
+    "static-readme-cli-version-badge",
+    "critical",
+    readmeCliBadgeVersion === cliVersion,
+    `README.md CLI badge equals CLI version ${cliVersion}`,
+    readmeCliBadgeVersion ? `badge=${readmeCliBadgeVersion}` : "CLI badge not found",
   ));
 
   const cliReadme = await readTextIfExists(path.join(ROOT, "cli", "README.md"));
@@ -314,7 +330,7 @@ async function runStaticChecks({ level }) {
     "blocker",
     cliReadme.includes("Node.js 20 LTS")
       && cliReadme.includes("npm install -g --force")
-      && cliReadme.includes(`lynn-cli-${version}.tgz`)
+      && cliReadme.includes(`lynn-cli-${cliVersion}.tgz`)
       && cliReadme.includes("Lynn code -p"),
     "cli/README.md documents Node requirement, CDN install, and headless code usage",
   ));
@@ -333,7 +349,7 @@ async function runStaticChecks({ level }) {
     "static-cli-mirror-snippet",
     "blocker",
     installSnippet.includes("Node.js 20 LTS")
-      && installSnippet.includes(`lynn-cli-${version}.tgz`)
+      && installSnippet.includes(`lynn-cli-${cliVersion}.tgz`)
       && installSnippet.includes("Lynn agents"),
     "CLI mirror/release snippet includes Node requirement, CDN install, and launch commands",
   ));
@@ -343,7 +359,7 @@ async function runStaticChecks({ level }) {
     "blocker",
     downloadPage.includes("Node.js 20 LTS")
       && downloadPage.includes("npm install -g --force")
-      && downloadPage.includes(`lynn-cli-${version}.tgz`)
+      && downloadPage.includes(`lynn-cli-${cliVersion}.tgz`)
       && downloadPage.includes("Lynn code")
       && downloadPage.includes("Lynn agents")
       && downloadPage.includes("data-copy-target=\"cli-install\"")

--- a/site/download.html
+++ b/site/download.html
@@ -126,7 +126,7 @@
             <span class="eyebrow">Lynn CLI / Lynn Code</span>
             <h2>给开发者和其他智能体的安装方式</h2>
             <p>
-              Lynn CLI 当前最新为 <strong>v0.80.2</strong>。它是 Lynn 的终端版:跑在命令行里的 AI 编码助手,带 Ink TUI、Markdown 渲染、流式输出、工具调用和长任务续跑。
+              Lynn CLI 当前最新为 <strong>v0.80.3</strong>。它是 Lynn 的终端版:跑在命令行里的 AI 编码助手,带 Ink TUI、Markdown 渲染、流式输出、工具调用和长任务续跑。
               一行命令装好,不用克隆仓库、不用编译;也可以被 Claude Code、Codex CLI、Kimi Code、Qwen CLI、CI 或 Lynn GUI Fleet 以无交互方式调用。
             </p>
           </div>
@@ -158,7 +158,7 @@ winget install OpenJS.NodeJS.LTS</code></pre>
             </div>
             <div class="code-copy-block">
               <button class="copy-button" type="button" data-copy-target="cli-install">复制</button>
-              <pre><code id="cli-install">npm install -g --force https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.2-apple-terminal-stable.tgz</code></pre>
+              <pre><code id="cli-install">npm install -g --force https://download.merkyorlynn.com/downloads/cli/lynn-cli-0.80.3.tgz</code></pre>
             </div>
           </div>
           <div class="cli-install-card">
@@ -171,7 +171,7 @@ winget install OpenJS.NodeJS.LTS</code></pre>
               <button class="copy-button" type="button" data-copy-target="cli-start">复制</button>
               <pre><code id="cli-start">Lynn                 # 交互式聊天 TUI
 Lynn code            # 编码 agent TUI
-Lynn --version       # 应输出 0.80.2
+Lynn --version       # 应输出 0.80.3
 Lynn agents          # 输出可复制的 Fleet / 其他 CLI 调用方式
 
 # 无交互编码 worker 示例


### PR DESCRIPTION
## Summary
- update README, README_EN, CLI README, install snippet, and mirror download page to the v0.80.3 CLI tarball
- teach release static checks that the desktop app version and CLI version can intentionally differ
- require `stress:cli` in release preflight static validation

## Local verification
- `npm run test:release:static` (55/55)
- `LYNN_CLI_STRESS_SERIAL=4 LYNN_CLI_STRESS_PARALLEL=2 LYNN_CLI_STRESS_APPLE_TURNS=8 npm --prefix cli run stress:cli`