### PR TITLE
fix(cli): answer model route questions locally

### DIFF
--- a/cli/src/runtime-answer.ts
+++ b/cli/src/runtime-answer.ts
@@ -17,11 +17,21 @@ const VERSION_PATTERNS = [
   /\b(?:what|which|show|tell|current|your|runtime|cli|lynn)\b.{0,28}\b(?:version|about)\b/i,
 ];
 
+const MODEL_ROUTE_PATTERNS = [
+  /(^|\s)\/model(\s|$)/i,
+  /(?:你|当前|现在|本地|运行时|命令行|cli|lynn).{0,16}(?:模型|model|路由|route)/i,
+  /(?:工作|使用|正在用|当前).{0,12}(?:模型|model)/i,
+  /(?:模型|model).{0,12}(?:是什么|是哪|哪个|\broute\b|using|running)/i,
+  /\b(?:what|which|show|tell|current|your|runtime|cli|lynn)\b.{0,32}\b(?:model|route)\b/i,
+  /\b(?:model|route)\b.{0,24}\b(?:using|running|current|active)\b/i,
+];
+
 export function isLocalRuntimeQuestion(text: string): boolean {
   const value = text.trim();
   if (!value) return false;
   if (/^(?:version|about)$/i.test(value)) return true;
-  return VERSION_PATTERNS.some((pattern) => pattern.test(value));
+  return VERSION_PATTERNS.some((pattern) => pattern.test(value))
+    || MODEL_ROUTE_PATTERNS.some((pattern) => pattern.test(value));
 }
 
 export function renderLocalRuntimeAnswer(input: RuntimeAnswerContext, locale: "zh" | "en" = "zh"): string {

--- a/cli/tests/code-tools.test.ts
+++ b/cli/tests/code-tools.test.ts
@@ -541,6 +541,31 @@ describe("code tools", () => {
     expect(output).not.toContain("fetch failed");
   });
 
+  it("answers code headless model route questions locally", async () => {
+    const original = process.stdout.write;
+    let output = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      output += String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await expect(runCode(parseArgs([
+        "code",
+        "-p",
+        "你现在工作模型是什么模型",
+        "--json",
+        "--brain-url",
+        "http://127.0.0.1:1",
+      ]))).resolves.toBe(0);
+    } finally {
+      process.stdout.write = original;
+    }
+    expect(output).toContain("\"type\":\"assistant.delta\"");
+    expect(output).toContain("模型路由:StepFun 3.7 Flash");
+    expect(output).toContain("\"local\":true");
+    expect(output).not.toContain("fetch failed");
+  });
+
   it("renders an interactive code-mode intro with full model route and permission mode", () => {
     const intro = renderCodeIntro({ approval: "ask", sandbox: "workspace-write" });
 

--- a/cli/tests/prompt.test.ts
+++ b/cli/tests/prompt.test.ts
@@ -47,6 +47,32 @@ describe("prompt stdin handling", () => {
     expect(output).toContain("\"local\":true");
   });
 
+  it("answers local model route questions without contacting Brain", async () => {
+    const original = process.stdout.write;
+    let output = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      output += String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await expect(runPrompt(parseArgs([
+        "-p",
+        "你现在工作模型是什么模型",
+        "--json",
+        "--brain-url",
+        "http://127.0.0.1:1",
+      ]), { json: true })).resolves.toBe(0);
+    } finally {
+      process.stdout.write = original;
+    }
+
+    expect(output).toContain("\"type\":\"assistant.delta\"");
+    expect(output).toContain("模型路由:StepFun 3.7 Flash");
+    expect(output).toContain("Lynn CLI 版本");
+    expect(output).toContain("\"local\":true");
+    expect(output).not.toContain("fetch failed");
+  });
+
   it("runs prompt mode through CLI BYOK when local Brain is offline", async () => {
     const provider = http.createServer((request, response) => {
       expect(request.url).toBe("/v1/chat/completions");

--- a/cli/tests/runtime-answer.test.ts
+++ b/cli/tests/runtime-answer.test.ts
@@ -5,11 +5,18 @@ describe("runtime answer", () => {
   it("detects local version and about questions", () => {
     expect(isLocalRuntimeQuestion("/version")).toBe(true);
     expect(isLocalRuntimeQuestion("/about")).toBe(true);
+    expect(isLocalRuntimeQuestion("/model")).toBe(true);
     expect(isLocalRuntimeQuestion("你的版本号")).toBe(true);
+    expect(isLocalRuntimeQuestion("你现在工作模型是什么模型")).toBe(true);
+    expect(isLocalRuntimeQuestion("当前模型路由是什么")).toBe(true);
     expect(isLocalRuntimeQuestion("what version are you?")).toBe(true);
+    expect(isLocalRuntimeQuestion("what model are you using?")).toBe(true);
+    expect(isLocalRuntimeQuestion("show the active route")).toBe(true);
     expect(isLocalRuntimeQuestion("帮我写一个版本比较函数")).toBe(false);
+    expect(isLocalRuntimeQuestion("帮我实现一个模型选择器")).toBe(false);
     expect(isLocalRuntimeQuestion("bump the package version in package.json")).toBe(false);
     expect(isLocalRuntimeQuestion("write a semantic version comparator")).toBe(false);
+    expect(isLocalRuntimeQuestion("train a model router from logs")).toBe(false);
   });
 
   it("renders the local CLI version instead of asking the model", () => {
@@ -28,6 +35,7 @@ describe("runtime answer", () => {
 
   it("uses English for English prompts", () => {
     expect(localeForText("what version are you?")).toBe("en");
+    expect(localeForText("what model are you using?")).toBe("en");
     expect(localeForText("你的版本号")).toBe("zh");
   });
 });


### PR DESCRIPTION
## Summary
- Treat natural-language model and route questions as local runtime questions.
- Answer Chinese prompt “你现在工作模型是什么模型” and English prompt “what model are you using?” without contacting Brain.
- Cover prompt and code headless paths so scripts/Fleet do not get model hallucinations.

## Verification
- npm --prefix cli run typecheck
- npm --prefix cli test -- runtime-answer prompt code-tools terminal-safety tui-input brain-render decode-speed --reporter=dot
- npm run build:cli && node cli/bin/lynn.mjs -p "你现在工作模型是什么模型" --json --brain-url http://127.0.0.1:1
- npm --prefix cli run stress:cli
- LYNN_CLI_TERMINAL_APP_TURNS=3 npm run test:cli-terminal-app