### PR TITLE
test(cli): scale Terminal.app smoke timeout

### DIFF
--- a/scripts/cli-terminal-app-smoke.mjs
+++ b/scripts/cli-terminal-app-smoke.mjs
@@ -52,7 +52,8 @@ end run
 `;
 
 await fs.writeFile(appleScriptPath, appleScript, "utf8");
-await execFileAsync("osascript", [appleScriptPath, root, statusPath, transcriptPath, String(commands.length)], { timeout: 45_000 });
+const appleScriptTimeoutMs = Math.max(45_000, commands.length * 1_500 + 15_000);
+await execFileAsync("osascript", [appleScriptPath, root, statusPath, transcriptPath, String(commands.length)], { timeout: appleScriptTimeoutMs });
 
 const deadline = Date.now() + Math.max(45_000, turns * 4_000 + 20_000);
 while (Date.now() < deadline) {


### PR DESCRIPTION
## Summary
- scale the Terminal.app smoke osascript timeout with the requested turn count
- allow long local Apple Terminal smoke runs such as 80 Chinese turns without false timeout failures

## Verification
- LYNN_CLI_TERMINAL_APP_TURNS=80 npm run test:cli-terminal-app
- LYNN_CLI_STRESS_SERIAL=80 LYNN_CLI_STRESS_PARALLEL=12 LYNN_CLI_STRESS_APPLE_TURNS=100 npm --prefix cli run stress:cli
- npm run test:release:static