### PR TITLE
fix(cli): handle local exit and read-only commands

### DIFF
--- a/cli/src/commands/chat.ts
+++ b/cli/src/commands/chat.ts
@@ -28,6 +28,7 @@ import { shouldUseInkTui } from "../terminal-safety.js";
 import { createDecodeSpeedTracker } from "../decode-speed.js";
 import { createRuntimeMetrics, recordDecodeTps, recordUsageMetrics, renderRuntimeMetrics } from "../runtime-metrics.js";
 import { compactChatMessages } from "../chat-compaction.js";
+import { isLocalExitText, parseLocalReadOnlyCommand, renderLocalReadOnlyBlocked, renderLocalReadOnlyResult, runLocalReadOnlyCommand } from "../local-command.js";
 
 export const CHAT_SLASH_COMMANDS = [
   "/yolo",
@@ -110,8 +111,8 @@ export async function runChat(args: ParsedArgs, options: { intro?: boolean; brai
   async function handleText(raw: string): Promise<"continue" | "break"> {
     const text = normalizeSlashInput(raw.trim());
     if (!text) return "continue";
+    if (isLocalExitText(text)) return "break";
     appendHistory(text, histFile);
-    if (text === "/exit" || text === "/quit") return "break";
     if (text === "/help") {
       output.write(`${t("chat.help")}\n\n`);
       return "continue";
@@ -233,6 +234,16 @@ export async function runChat(args: ParsedArgs, options: { intro?: boolean; brai
     }
     if (text === "/cwd" || text === "/pwd") {
       output.write(`${t("cwd.info", { cwd: chatCwd })}\n\n`);
+      return "continue";
+    }
+    const localReadOnly = parseLocalReadOnlyCommand(text, chatCwd);
+    if (localReadOnly?.kind === "blocked") {
+      output.write(`${renderLocalReadOnlyBlocked(localReadOnly, output)}\n\n`);
+      return "continue";
+    }
+    if (localReadOnly?.kind === "command") {
+      const result = await runLocalReadOnlyCommand(localReadOnly.command);
+      output.write(`${renderLocalReadOnlyResult(localReadOnly.command, result, output)}\n\n`);
       return "continue";
     }
     const memoryCommand = await handleMemorySlashCommand(text, dataDir);

--- a/cli/src/commands/code.ts
+++ b/cli/src/commands/code.ts
@@ -28,6 +28,7 @@ import { prepareCodeTaskInput } from "../code-input.js";
 import { resolveDefaultBrainUrl } from "../brain-url.js";
 import { isLocalRuntimeQuestion, localeForText, renderLocalRuntimeAnswer } from "../runtime-answer.js";
 import { renderPlanCard } from "../terminal-spinner.js";
+import { isLocalExitText, parseLocalReadOnlyCommand, renderLocalReadOnlyBlocked, renderLocalReadOnlyResult, runLocalReadOnlyCommand } from "../local-command.js";
 import {
   assistantToolCallsForMessages,
   codeToolDefinitions,
@@ -321,6 +322,7 @@ async function runCodeInteractive(args: ParsedArgs): Promise<number> {
   const mode = await resolveCodeMode(args);
   let reasoning = parseReasoningOptions(args);
   let cliProvider = await resolveCliProviderProfile(args);
+  const interactiveCwd = getStringFlag(args.flags, "cwd") || process.cwd();
   output.write(renderCodeIntro(mode, reasoning, { color: supportsColor(output), modelLabel: codeRouteLabel(false, cliProvider?.profile) }));
   const histFile = historyPath();
   const history = loadHistory(histFile);
@@ -367,9 +369,9 @@ async function runCodeInteractive(args: ParsedArgs): Promise<number> {
       if (raw === null) break;
       const text = normalizeSlashInput(raw.trim());
       if (!text) continue;
+      if (isLocalExitText(text)) break;
       history.push(text);
       appendHistory(text, histFile);
-      if (text === "/exit" || text === "/quit") break;
       if (text === "/help") {
         output.write(`${t("code.help")}\n\n`);
         continue;
@@ -506,6 +508,16 @@ async function runCodeInteractive(args: ParsedArgs): Promise<number> {
       }
       if (text.startsWith("/providers ") || text.startsWith("/byok ")) {
         output.write(`${t("chat.providers.usage")}\n\n`);
+        continue;
+      }
+      const localReadOnly = parseLocalReadOnlyCommand(text, interactiveCwd);
+      if (localReadOnly?.kind === "blocked") {
+        output.write(`${renderLocalReadOnlyBlocked(localReadOnly, output)}\n\n`);
+        continue;
+      }
+      if (localReadOnly?.kind === "command") {
+        const result = await runLocalReadOnlyCommand(localReadOnly.command);
+        output.write(`${renderLocalReadOnlyResult(localReadOnly.command, result, output)}\n\n`);
         continue;
       }
       if (text.startsWith("/")) {

--- a/cli/src/local-command.ts
+++ b/cli/src/local-command.ts
@@ -1,0 +1,150 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { dim, red, supportsColor } from "./terminal-style.js";
+import { renderCard } from "./terminal-spinner.js";
+
+export interface LocalReadOnlyCommand {
+  name: "pwd" | "ls";
+  display: string;
+  cwd: string;
+  target?: string;
+  all?: boolean;
+  long?: boolean;
+}
+
+export type LocalReadOnlyParseResult =
+  | { kind: "command"; command: LocalReadOnlyCommand }
+  | { kind: "blocked"; display: string; reason: string }
+  | null;
+
+const EXIT_TEXT = new Set(["/exit", "/quit", "exit", "quit", "bye", "再见", "拜拜", "退出", "结束"]);
+const LS_FLAGS = new Set(["-a", "-l", "-la", "-al", "-1", "-h", "-lh", "-hl", "-lah", "-lha", "-alh", "-ahl"]);
+
+export function isLocalExitText(raw: string): boolean {
+  return EXIT_TEXT.has(raw.trim().toLowerCase());
+}
+
+export function parseLocalReadOnlyCommand(raw: string, cwd = process.cwd()): LocalReadOnlyParseResult {
+  const tokens = splitCommand(raw);
+  if (!tokens.length) return null;
+  const head = tokens[0]?.toLowerCase();
+  if (head !== "pwd" && head !== "ls" && head !== "ll") return null;
+  const display = tokens.join(" ");
+  if (head === "pwd") {
+    return tokens.length === 1
+      ? { kind: "command", command: { name: "pwd", display, cwd } }
+      : { kind: "blocked", display, reason: "pwd does not accept arguments here" };
+  }
+
+  const args = head === "ll" ? ["-la", ...tokens.slice(1)] : tokens.slice(1);
+  let all = false;
+  let long = false;
+  let target: string | undefined;
+  for (const arg of args) {
+    if (arg.startsWith("-")) {
+      if (!LS_FLAGS.has(arg)) return { kind: "blocked", display, reason: `unsupported ls flag: ${arg}` };
+      if (arg.includes("a")) all = true;
+      if (arg.includes("l")) long = true;
+      continue;
+    }
+    if (target) return { kind: "blocked", display, reason: "only one relative path is supported" };
+    const checked = validateRelativeTarget(arg);
+    if (!checked.ok) return { kind: "blocked", display, reason: checked.reason };
+    target = arg;
+  }
+  return { kind: "command", command: { name: "ls", display, cwd, target, all, long } };
+}
+
+export function isSafeReadOnlyShellCommand(raw: string): boolean {
+  return parseLocalReadOnlyCommand(raw)?.kind === "command";
+}
+
+export async function runLocalReadOnlyCommand(command: LocalReadOnlyCommand): Promise<{ ok: boolean; output: string; error?: string }> {
+  if (command.name === "pwd") return { ok: true, output: `${command.cwd}\n` };
+  const targetPath = command.target ? path.resolve(command.cwd, command.target) : command.cwd;
+  if (!isInside(command.cwd, targetPath)) return { ok: false, output: "", error: "path is outside the current workspace" };
+  try {
+    const stat = await fs.stat(targetPath);
+    if (!stat.isDirectory()) return { ok: true, output: `${path.basename(targetPath)}\n` };
+    const entries = await fs.readdir(targetPath, { withFileTypes: true });
+    const rows = entries
+      .filter((entry) => command.all || !entry.name.startsWith("."))
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((entry) => {
+        const suffix = entry.isDirectory() ? "/" : "";
+        return command.long ? `${entry.isDirectory() ? "d" : "-"} ${entry.name}${suffix}` : `${entry.name}${suffix}`;
+      });
+    return { ok: true, output: rows.length ? `${rows.join("\n")}\n` : "(empty)\n" };
+  } catch (error) {
+    return { ok: false, output: "", error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export function renderLocalReadOnlyResult(command: LocalReadOnlyCommand, result: { ok: boolean; output: string; error?: string }, stream: Pick<NodeJS.WriteStream, "isTTY"> = process.stdout): string {
+  const color = supportsColor(stream);
+  const lines = result.ok ? trimOutput(result.output) : [result.error || "command failed"];
+  return renderCard({
+    kind: result.ok ? "ok" : "error",
+    title: `local ${command.display}`,
+    body: lines,
+  }, color);
+}
+
+export function renderLocalReadOnlyBlocked(blocked: Extract<LocalReadOnlyParseResult, { kind: "blocked" }>, stream: Pick<NodeJS.WriteStream, "isTTY"> = process.stdout): string {
+  const color = supportsColor(stream);
+  return renderCard({
+    kind: "error",
+    title: `local ${blocked.display}`,
+    body: [
+      red("not run", color),
+      dim(blocked.reason, color),
+      "Supported here: pwd, ls, ls -la, ll, and one relative path inside the current workspace.",
+    ],
+  }, color);
+}
+
+function trimOutput(output: string): string[] {
+  const rows = output.replace(/\s+$/g, "").split(/\r?\n/);
+  if (rows.length <= 80) return rows;
+  return [...rows.slice(0, 80), `... ${rows.length - 80} more line(s)`];
+}
+
+function validateRelativeTarget(value: string): { ok: true } | { ok: false; reason: string } {
+  if (!value || value === ".") return { ok: true };
+  if (path.isAbsolute(value)) return { ok: false, reason: "absolute paths are not allowed for this shortcut" };
+  if (value === "~" || value.startsWith("~/")) return { ok: false, reason: "home paths are not allowed for this shortcut" };
+  if (value.split(/[\\/]+/).includes("..")) return { ok: false, reason: "parent-directory traversal is not allowed" };
+  return { ok: true };
+}
+
+function isInside(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return !relative || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function splitCommand(raw: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+  for (const char of raw.trim()) {
+    if (quote) {
+      if (char === quote) quote = null;
+      else current += char;
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}

--- a/cli/src/runtime-context.ts
+++ b/cli/src/runtime-context.ts
@@ -15,6 +15,7 @@ export function buildCliRuntimeSystemMessage(routeLabel: string, memoryFrame = "
       "StepFun 3.7 Flash is the text/coding head route. MiMo V2.5 Pro owns image/audio/video and native search fallback.",
       "Detailed Lynn CLI implementation notes live in docs/ops/lynn-cli-runtime-knowledge.md; local runtime questions may be answered by Lynn itself before the model is called.",
       "The user can change CLI-only BYOK with /model, /providers, or /setup; those slash commands are handled by Lynn locally.",
+      "Lynn handles exact local read-only commands like pwd, ls, ls -la, and ll before the model; do not claim Lynn cannot list the current directory. Arbitrary shell, edits, and destructive commands still require YOLO.",
       "If asked how to use -p, silent mode, headless mode, scripts, CI, or another agent calling Lynn, answer directly with copyable Lynn commands. Do not say Lynn is only interactive.",
       "Headless one-shot: Lynn -p \"prompt\" --json. Headless coding agent: Lynn code -p \"task\" --json --cwd /path/to/worktree --approval yolo --sandbox workspace-write --save-session.",
       "Fleet worker adapter: Lynn worker run --brief task.md --worktree /path/to/worktree --jsonl --approval yolo --sandbox workspace-write. Custom external worker: add --agent custom --agent-command \"your command\".",

--- a/cli/src/tools/bash.ts
+++ b/cli/src/tools/bash.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { ClientToolResult, ToolRunContext } from "./types.js";
+import { isSafeReadOnlyShellCommand } from "../local-command.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_STREAM_BYTES = 1_000_000;
@@ -62,10 +63,10 @@ export function assertWorkspaceBashAllowed(command: string, sandbox: ToolRunCont
 
 export async function bashTool(ctx: ToolRunContext, command: string): Promise<ClientToolResult> {
   if (!command) throw new Error("--command is required for bash");
-  if (ctx.approval !== "yolo") {
-    throw new Error("bash requires YOLO approval. Run /mode yolo in interactive code mode or pass --approval yolo.");
-  }
   assertWorkspaceBashAllowed(command, ctx.sandbox || "workspace-write");
+  if (ctx.approval !== "yolo" && !isSafeReadOnlyShellCommand(command)) {
+    throw new Error("bash requires YOLO approval except for safe read-only pwd/ls shortcuts. Run /mode yolo in interactive code mode or pass --approval yolo.");
+  }
   auditBash(command, ctx.cwd);
   return new Promise((resolve) => {
     const child = spawn(command, {

--- a/cli/tests/bash-sandbox.test.ts
+++ b/cli/tests/bash-sandbox.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { assertWorkspaceBashAllowed } from "../src/tools/bash.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { assertWorkspaceBashAllowed, bashTool } from "../src/tools/bash.js";
 
 const check = (command: string) => () => assertWorkspaceBashAllowed(command, "workspace-write");
 
@@ -29,5 +32,19 @@ describe("assertWorkspaceBashAllowed", () => {
 
   it("allows everything in danger-full-access", () => {
     expect(() => assertWorkspaceBashAllowed("find . -delete", "danger-full-access")).not.toThrow();
+  });
+
+  it("allows only safe pwd/ls bash without yolo approval", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "lynn-bash-safe-"));
+    try {
+      await fs.writeFile(path.join(dir, "ok.txt"), "ok", "utf8");
+      await expect(bashTool({ cwd: dir, approval: "ask", sandbox: "workspace-write" }, "pwd")).resolves.toMatchObject({ ok: true });
+      const listed = await bashTool({ cwd: dir, approval: "ask", sandbox: "workspace-write" }, "ls");
+      expect(listed.ok).toBe(true);
+      expect(JSON.stringify(listed.output)).toContain("ok.txt");
+      await expect(bashTool({ cwd: dir, approval: "ask", sandbox: "workspace-write" }, "git status")).rejects.toThrow(/requires YOLO approval/);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/cli/tests/chat.test.ts
+++ b/cli/tests/chat.test.ts
@@ -32,6 +32,40 @@ const pythonIt = hasPython3() ? it : it.skip;
 const ptyIt = process.platform === "win32" ? it.skip : pythonIt;
 const interactivePtyIt = process.env.CI === "true" ? it.skip : ptyIt;
 
+async function runInteractiveChatInput(
+  inputText: string,
+  options: { args?: string[]; timeoutMs?: number } = {},
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [
+      "--import",
+      "tsx",
+      "src/cli.ts",
+      ...(options.args || []),
+      "--mock-brain",
+    ], {
+      cwd: cliRoot,
+      env: { ...process.env, NO_COLOR: "1", LYNN_LANG: "en" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error("interactive chat fixture did not exit"));
+    }, options.timeoutMs || 5000);
+    child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+    child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+    child.stdin.write(inputText);
+    child.stdin.end();
+  });
+}
+
 beforeEach(() => setLang("en"));
 afterEach(() => setLang(null));
 
@@ -256,6 +290,43 @@ describe("chat mode controls", () => {
       expect(result.code).toBe(0);
       expect(result.stdout).toContain(targetCwd);
       expect(result.stdout).not.toContain("Usage:");
+    } finally {
+      await fs.rm(targetCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("handles exact local exit phrases without sending them to the model", async () => {
+    const english = await runInteractiveChatInput("exit\n");
+    const chinese = await runInteractiveChatInput("再见\n");
+
+    expect(english.code).toBe(0);
+    expect(chinese.code).toBe(0);
+    expect(english.stdout).not.toContain("Mock Lynn response");
+    expect(chinese.stdout).not.toContain("Mock Lynn response");
+    expect(english.stdout).not.toContain("模拟回复");
+    expect(chinese.stdout).not.toContain("模拟回复");
+  });
+
+  it("runs local pwd and ls shortcuts without yolo or model fallback", async () => {
+    const targetCwd = await fs.mkdtemp(path.join(os.tmpdir(), "lynn-chat-local-ls-"));
+    try {
+      await fs.writeFile(path.join(targetCwd, "alpha.txt"), "alpha", "utf8");
+      await fs.mkdir(path.join(targetCwd, "subdir"));
+
+      const result = await runInteractiveChatInput("pwd\nls\n/exit\n", {
+        args: ["--cwd", targetCwd],
+      });
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("local pwd");
+      expect(result.stdout).toContain(targetCwd);
+      expect(result.stdout).toContain("local ls");
+      expect(result.stdout).toContain("alpha.txt");
+      expect(result.stdout).toContain("subdir/");
+      expect(result.stdout).not.toContain("Mock Lynn response:pwd");
+      expect(result.stdout).not.toContain("Mock Lynn response:ls");
+      expect(result.stdout).not.toContain("模拟回复:pwd");
+      expect(result.stdout).not.toContain("模拟回复:ls");
     } finally {
       await fs.rm(targetCwd, { recursive: true, force: true });
     }

--- a/cli/tests/code-tools.test.ts
+++ b/cli/tests/code-tools.test.ts
@@ -77,10 +77,11 @@ describe("code tools", () => {
     expect(globToRegExp("**/*.ts").test("src/hello.ts")).toBe(true);
   });
 
-  it("requires yolo approval for writes and bash", async () => {
+  it("requires yolo approval for writes and arbitrary bash", async () => {
     await expect(runClientTool({ cwd: tmp, approval: "ask" }, { name: "write_file", path: "out.txt", text: "x" })).rejects.toThrow("approval yolo");
     await expect(runClientTool({ cwd: tmp, approval: "ask" }, { name: "apply_patch", text: "diff --git a/x b/x\n" })).rejects.toThrow("approval yolo");
-    await expect(runClientTool({ cwd: tmp, approval: "ask" }, { name: "bash", command: "pwd" })).rejects.toThrow("approval yolo");
+    await expect(runClientTool({ cwd: tmp, approval: "ask" }, { name: "bash", command: "pwd" })).resolves.toMatchObject({ ok: true, tool: "bash" });
+    await expect(runClientTool({ cwd: tmp, approval: "ask" }, { name: "bash", command: "git status" })).rejects.toThrow("requires YOLO approval");
   });
 
   it("blocks dangerous tools in read-only sandbox even with yolo approval", async () => {

--- a/cli/tests/local-command.test.ts
+++ b/cli/tests/local-command.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isLocalExitText, isSafeReadOnlyShellCommand, parseLocalReadOnlyCommand, runLocalReadOnlyCommand } from "../src/local-command.js";
+
+describe("local read-only command shortcuts", () => {
+  it("recognizes local exit phrases without sending them to the model", () => {
+    expect(isLocalExitText("exit")).toBe(true);
+    expect(isLocalExitText("/quit")).toBe(true);
+    expect(isLocalExitText("再见")).toBe(true);
+    expect(isLocalExitText("再见 帮我总结")).toBe(false);
+  });
+
+  it("parses only narrow pwd/ls commands", () => {
+    expect(parseLocalReadOnlyCommand("pwd")?.kind).toBe("command");
+    expect(parseLocalReadOnlyCommand("ls")?.kind).toBe("command");
+    expect(parseLocalReadOnlyCommand("ls -la docs")?.kind).toBe("command");
+    expect(parseLocalReadOnlyCommand("ll")?.kind).toBe("command");
+    expect(parseLocalReadOnlyCommand("ls /etc")?.kind).toBe("blocked");
+    expect(parseLocalReadOnlyCommand("ls ..")?.kind).toBe("blocked");
+    expect(parseLocalReadOnlyCommand("ls; rm -rf .")).toBeNull();
+    expect(isSafeReadOnlyShellCommand("git status")).toBe(false);
+  });
+
+  it("runs pwd and ls without shelling out", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "lynn-local-cmd-"));
+    try {
+      await fs.writeFile(path.join(dir, "a.txt"), "ok", "utf8");
+      await fs.mkdir(path.join(dir, "sub"));
+      const pwd = parseLocalReadOnlyCommand("pwd", dir);
+      const ls = parseLocalReadOnlyCommand("ls", dir);
+      if (pwd?.kind !== "command" || ls?.kind !== "command") throw new Error("parse failed");
+
+      await expect(runLocalReadOnlyCommand(pwd.command)).resolves.toMatchObject({ ok: true, output: `${dir}\n` });
+      const listed = await runLocalReadOnlyCommand(ls.command);
+      expect(listed.ok).toBe(true);
+      expect(listed.output).toContain("a.txt");
+      expect(listed.output).toContain("sub/");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- handle exact local exit phrases such as exit, /exit, 再见, 退出 before model calls\n- run safe local read-only shortcuts (pwd, ls, ll) in chat/code without YOLO or model fallback\n- allow only those pwd/ls bash shortcuts without YOLO while keeping writes/arbitrary shell gated\n- teach runtime context not to claim Lynn cannot list the current directory\n\n## Tests\n- npm --prefix cli run typecheck\n- npm --prefix cli exec vitest run tests/local-command.test.ts tests/bash-sandbox.test.ts tests/chat.test.ts tests/code-tools.test.ts\n- npm --prefix cli test\n- npm --prefix cli run build\n- built bundle smoke: pwd + ls + 再见 via node cli/bin/lynn.mjs --mock-brain --cwd <tmp>\n