### PR TITLE
fix: recover GUI startup from legacy facts db

### DIFF
--- a/core/first-run.ts
+++ b/core/first-run.ts
@@ -91,7 +91,7 @@ function firstExistingPath(...paths: Array<string | null | undefined>): string |
  * @param {string} productDir - 产品模板目录（lib/）
  */
 export function ensureFirstRun(lynnHome: string, productDir: string): void {
-  // 0. 迁移旧数据目录 ~/.hanako → ~/.lynn
+  // 0. 从旧数据目录 ~/.hanako 复制首份 Lynn 数据；保留 OpenHanako 原目录
   migrateFromHanako(lynnHome);
 
   // 1. 确保目录结构存在
@@ -152,8 +152,9 @@ export function ensureFirstRun(lynnHome: string, productDir: string): void {
 }
 
 /**
- * 从旧版 ~/.hanako 迁移到 ~/.lynn
- * 如果 ~/.lynn 已存在则跳过（用户已迁移或全新安装）
+ * 从旧版 ~/.hanako 复制首份数据到 ~/.lynn。
+ * 如果 ~/.lynn 已存在则跳过（用户已迁移或全新安装）。
+ * 注意：不能 rename/move 旧目录，否则 OpenHanako 用户会丢失自己的应用数据。
  */
 function migrateFromHanako(lynnHome: string): void {
   const defaultLynn = path.join(os.homedir(), ".lynn");
@@ -164,8 +165,8 @@ function migrateFromHanako(lynnHome: string): void {
   if (fs.existsSync(defaultLynn)) return; // 新目录已存在，不覆盖
 
   try {
-    fs.renameSync(oldHome, defaultLynn);
-    console.log(`[first-run] 已迁移数据目录: ~/.hanako → ~/.lynn`);
+    safeCopyDir(oldHome, defaultLynn);
+    console.log(`[first-run] 已从旧数据目录复制初始数据: ~/.hanako → ~/.lynn`);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`[first-run] 数据目录迁移失败 (${message})，将使用新目录`);

--- a/docs/ops/download-site-deploy-map.md
+++ b/docs/ops/download-site-deploy-map.md
@@ -13,6 +13,10 @@ The static page and binary downloads do not live in the same directory.
 | `https://download.merkyorlynn.com/downloads/cli/*` | `/opt/lobster-brain/public/downloads/cli/*` | nginx `alias`; not under `/var/www/download-site` |
 | `https://download.merkyorlynn.com/downloads/*` | `/opt/lobster-brain/public/downloads/*` | App installers and other downloadable assets |
 
+Release reminder: upload GUI installer assets to `/opt/lobster-brain/public/downloads/`,
+not to `/var/www/download-site/downloads/`. The `/var/www/download-site` tree only
+serves the static page shell (`download.html`, `app.js`, images, CSS).
+
 ## CLI Release Checklist
 
 1. Build the CLI package only through the guarded script:
@@ -47,3 +51,38 @@ The static page and binary downloads do not live in the same directory.
 
 The release is not considered published until the public URL returns `200`,
 the sha256 matches the local pack manifest, and remote install smoke passes.
+
+## GUI Release Checklist
+
+1. Build, sign, notarize, staple, and Gatekeeper-validate each platform artifact.
+
+2. Upload installers, blockmaps, and updater manifests to the nginx alias directory:
+
+   ```bash
+   VERSION=<gui-version>
+   rsync -av \
+     dist/Lynn-${VERSION}-macOS-arm64.dmg \
+     dist/Lynn-${VERSION}-macOS-arm64.dmg.blockmap \
+     dist/Lynn-${VERSION}-macOS-x64.dmg \
+     dist/Lynn-${VERSION}-macOS-x64.dmg.blockmap \
+     dist/Lynn-${VERSION}-Windows-Setup.exe \
+     dist/Lynn-${VERSION}-Windows-Setup.exe.blockmap \
+     dist/latest-mac.yml \
+     dist/latest.yml \
+     tencent:/opt/lobster-brain/public/downloads/
+   ```
+
+3. Verify public URLs, not just server files:
+
+   ```bash
+   VERSION=<gui-version>
+   curl -fsSIL https://download.merkyorlynn.com/downloads/Lynn-${VERSION}-macOS-arm64.dmg
+   curl -fsSIL https://download.merkyorlynn.com/downloads/Lynn-${VERSION}-macOS-x64.dmg
+   curl -fsSIL https://download.merkyorlynn.com/downloads/Lynn-${VERSION}-Windows-Setup.exe
+   curl -fsSL https://download.merkyorlynn.com/downloads/latest-mac.yml
+   curl -fsSL https://download.merkyorlynn.com/downloads/latest.yml
+   ```
+
+4. If any public URL returns stale size/hash, first confirm that the files landed
+   under `/opt/lobster-brain/public/downloads/`; stale `/var/www/download-site/downloads/`
+   uploads do not affect public downloads.

--- a/lib/memory/fact-store.ts
+++ b/lib/memory/fact-store.ts
@@ -13,6 +13,8 @@
 
 // @ts-expect-error better-sqlite3 does not ship declarations in this project.
 import DatabaseModule from "better-sqlite3";
+import fs from "fs";
+import path from "path";
 import { scrubPII } from "../pii-guard.js";
 
 type SqliteRunResult = {
@@ -75,6 +77,24 @@ type FactStoreOptions = {
   hitBonus?: number;
   compileThreshold?: number;
 };
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function backupSqliteFileSet(dbPath: string): string | null {
+  if (!fs.existsSync(dbPath)) return null;
+  const backupPath = `${dbPath}.bak-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  fs.renameSync(dbPath, backupPath);
+  for (const ext of ["-wal", "-shm"]) {
+    const sidecarPath = dbPath + ext;
+    if (fs.existsSync(sidecarPath)) {
+      fs.renameSync(sidecarPath, backupPath + ext);
+    }
+  }
+  return backupPath;
+}
 
 type FactInput = {
   fact: string;
@@ -290,7 +310,7 @@ export class FactStore {
   readonly baseImportance: number;
   readonly hitBonus: number;
   readonly compileThreshold: number;
-  private readonly db: DatabaseInstance;
+  private db!: DatabaseInstance;
   private _stmts!: FactStatements;
   private readonly _tagSearchCache!: Map<string, SqliteStatement<FactDbRow>>;
   private _walTimer!: NodeJS.Timeout | null;
@@ -307,7 +327,37 @@ export class FactStore {
     this.compileThreshold = isFiniteNumber(opts.compileThreshold) ? opts.compileThreshold : 4.5;
     this._changeListeners = new Set();
 
-    this.db = new Database(dbPath);
+    this._openAndInitialize(dbPath);
+    this._tagSearchCache = new Map();
+
+    // Periodic WAL checkpoint to prevent unbounded WAL growth.
+    this._walTimer = setInterval(() => {
+      try { this.db.pragma("wal_checkpoint(PASSIVE)"); } catch {}
+    }, 3600_000);
+    if (this._walTimer.unref) this._walTimer.unref();
+  }
+
+  private _openAndInitialize(dbPath: string): void {
+    try {
+      fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+      this.db = new Database(dbPath);
+      this._initializeOpenDatabase();
+      return;
+    } catch (err) {
+      try {
+        if (this.db?.open) this.db.close();
+      } catch {}
+
+      const backupPath = backupSqliteFileSet(dbPath);
+      if (!backupPath) throw err;
+      console.warn(`[FactStore] facts.db unusable (${errorMessage(err)}); backed up to ${path.basename(backupPath)} and rebuilt an empty database`);
+
+      this.db = new Database(dbPath);
+      this._initializeOpenDatabase();
+    }
+  }
+
+  private _initializeOpenDatabase(): void {
     this.db.pragma("journal_mode = WAL");
     this.db.pragma("busy_timeout = 5000");
     this.db.pragma("synchronous = NORMAL");
@@ -318,13 +368,6 @@ export class FactStore {
     this._migrate();
     this._ensureDerivedIndexes();
     this._prepareStatements();
-    this._tagSearchCache = new Map();
-
-    // Periodic WAL checkpoint to prevent unbounded WAL growth.
-    this._walTimer = setInterval(() => {
-      try { this.db.pragma("wal_checkpoint(PASSIVE)"); } catch {}
-    }, 3600_000);
-    if (this._walTimer.unref) this._walTimer.unref();
   }
 
   private _initSchema(): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1693,6 +1693,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@cypress/request/node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
       "dev": true,
@@ -3087,6 +3102,21 @@
         "protobufjs": "^7.2.6",
         "qs": "^6.14.2",
         "ws": "^8.19.0"
+      }
+    },
+    "node_modules/@larksuiteoapi/node-sdk/node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@lezer/common": {
@@ -12739,19 +12769,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/qs": {
-      "version": "6.15.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "license": "MIT"
@@ -13031,6 +13048,22 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/request/node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "overrides": {
     "form-data": "^4.0.0",
-    "qs": "^6.14.1",
+    "qs": "6.14.1",
     "tough-cookie": "^4.1.3"
   },
   "devDependencies": {

--- a/tests/fact-store-recovery.test.js
+++ b/tests/fact-store-recovery.test.js
@@ -1,0 +1,156 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let rows;
+let nextId;
+let openFailuresRemaining;
+let prepareFailuresRemaining;
+
+class RecoverableDatabase {
+  constructor(filename) {
+    this.filename = filename;
+    this.open = true;
+    if (openFailuresRemaining > 0) {
+      openFailuresRemaining -= 1;
+      throw new Error("file is not a database");
+    }
+  }
+
+  pragma(source, opts) {
+    if (source === "user_version" && opts?.simple) return 5;
+    return [];
+  }
+
+  exec() {}
+
+  transaction(fn) {
+    return (...args) => fn(...args);
+  }
+
+  prepare(sql) {
+    if (prepareFailuresRemaining > 0 && sql.includes("INSERT INTO facts")) {
+      prepareFailuresRemaining -= 1;
+      throw new Error("SQLITE_ERROR: no such column: session_id");
+    }
+
+    if (sql.includes("INSERT INTO facts")) {
+      return {
+        run(params) {
+          const id = nextId++;
+          rows.push({
+            id,
+            fact: params.fact,
+            tags: params.tags || "[]",
+            time: params.time || null,
+            session_id: params.sessionId || null,
+            created_at: params.createdAt || new Date().toISOString(),
+            source: params.source || null,
+            project_path: params.projectPath || null,
+            importance_score: params.importanceScore || 0,
+            hit_count: params.hitCount || 0,
+            last_accessed_at: params.lastAccessedAt || null,
+            category: params.category || "other",
+            confidence: params.confidence ?? 0.5,
+            evidence: params.evidence || null,
+          });
+          return { changes: 1, lastInsertRowid: id };
+        },
+      };
+    }
+
+    if (sql.includes("SELECT * FROM facts ORDER BY time DESC")) {
+      return {
+        all() {
+          return rows;
+        },
+      };
+    }
+
+    if (sql.includes("SELECT COUNT(*) as cnt")) {
+      return {
+        get() {
+          return { cnt: rows.length };
+        },
+      };
+    }
+
+    return {
+      all() { return []; },
+      get() { return undefined; },
+      run() { return { changes: 0, lastInsertRowid: 1 }; },
+    };
+  }
+
+  close() {
+    this.open = false;
+  }
+}
+
+vi.mock("better-sqlite3", () => ({
+  default: RecoverableDatabase,
+}));
+
+const tempRoots = [];
+
+function makeTempRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "lynn-fact-recovery-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function listBackups(dir) {
+  return fs.readdirSync(dir).filter((name) => name.startsWith("facts.db.bak-"));
+}
+
+beforeEach(() => {
+  rows = [];
+  nextId = 1;
+  openFailuresRemaining = 0;
+  prepareFailuresRemaining = 0;
+});
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("FactStore startup recovery", () => {
+  it("backs up an unusable facts.db and rebuilds an empty store", async () => {
+    const root = makeTempRoot();
+    const dbPath = path.join(root, "facts.db");
+    fs.writeFileSync(dbPath, "not a sqlite database", "utf-8");
+    openFailuresRemaining = 1;
+
+    const { FactStore } = await import("../lib/memory/fact-store.js");
+    const store = new FactStore(dbPath);
+
+    expect(store.getAll()).toEqual([]);
+    store.add({ fact: "Lynn can restart after a broken facts database." });
+    expect(store.getAll()[0].fact).toContain("broken facts database");
+    store.close();
+
+    const backups = listBackups(root);
+    expect(backups).toHaveLength(1);
+    expect(fs.readFileSync(path.join(root, backups[0]), "utf-8")).toBe("not a sqlite database");
+  });
+
+  it("backs up an incompatible schema when statement preparation fails", async () => {
+    const root = makeTempRoot();
+    const dbPath = path.join(root, "facts.db");
+    fs.writeFileSync(dbPath, "sqlite file with incompatible latest-version schema", "utf-8");
+    prepareFailuresRemaining = 1;
+
+    const { FactStore } = await import("../lib/memory/fact-store.js");
+    const store = new FactStore(dbPath);
+
+    expect(store.getAll()).toEqual([]);
+    store.add({ fact: "Recovered from an incompatible facts schema." });
+    expect(store.getAll()[0].fact).toContain("incompatible facts schema");
+    store.close();
+
+    expect(listBackups(root)).toHaveLength(1);
+  });
+});

--- a/tests/first-run.test.js
+++ b/tests/first-run.test.js
@@ -44,6 +44,34 @@ afterEach(() => {
 });
 
 describe('ensureFirstRun', () => {
+  it('copies legacy ~/.hanako data into ~/.lynn without moving OpenHanako data away', () => {
+    const root = makeTempRoot();
+    tempRoots.push(root);
+    const productDir = makeProductDir(root);
+    const oldHome = path.join(root, '.hanako');
+    const lynnHome = path.join(root, '.lynn');
+    const oldHomeBefore = process.env.HOME;
+
+    fs.mkdirSync(path.join(oldHome, 'agents', 'hanako'), { recursive: true });
+    fs.writeFileSync(path.join(oldHome, 'openhanako-marker.txt'), 'openhanako-data\n', 'utf-8');
+    writeYaml(path.join(oldHome, 'agents', 'hanako', 'config.yaml'), {
+      agent: { name: 'Hanako', yuan: 'hanako' },
+    });
+
+    try {
+      process.env.HOME = root;
+      ensureFirstRun(lynnHome, productDir);
+    } finally {
+      if (oldHomeBefore === undefined) delete process.env.HOME;
+      else process.env.HOME = oldHomeBefore;
+    }
+
+    expect(fs.existsSync(oldHome)).toBe(true);
+    expect(fs.readFileSync(path.join(oldHome, 'openhanako-marker.txt'), 'utf-8')).toBe('openhanako-data\n');
+    expect(fs.existsSync(path.join(lynnHome, 'openhanako-marker.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(lynnHome, 'agents', 'hanako', 'config.yaml'))).toBe(true);
+  });
+
   it('migrates the legacy hanako primary assistant into lynn', () => {
     const root = makeTempRoot();
     tempRoots.push(root);

--- a/tests/first-run.test.js
+++ b/tests/first-run.test.js
@@ -51,6 +51,7 @@ describe('ensureFirstRun', () => {
     const oldHome = path.join(root, '.hanako');
     const lynnHome = path.join(root, '.lynn');
     const oldHomeBefore = process.env.HOME;
+    const oldUserProfileBefore = process.env.USERPROFILE;
 
     fs.mkdirSync(path.join(oldHome, 'agents', 'hanako'), { recursive: true });
     fs.writeFileSync(path.join(oldHome, 'openhanako-marker.txt'), 'openhanako-data\n', 'utf-8');
@@ -60,10 +61,13 @@ describe('ensureFirstRun', () => {
 
     try {
       process.env.HOME = root;
+      process.env.USERPROFILE = root;
       ensureFirstRun(lynnHome, productDir);
     } finally {
       if (oldHomeBefore === undefined) delete process.env.HOME;
       else process.env.HOME = oldHomeBefore;
+      if (oldUserProfileBefore === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = oldUserProfileBefore;
     }
 
     expect(fs.existsSync(oldHome)).toBe(true);


### PR DESCRIPTION
## Summary\n- recover from corrupt or legacy-schema facts.db by backing it up and rebuilding an empty store\n- copy OpenHanako ~/.hanako data instead of moving it during first-run migration\n- lock qs override to 6.14.1 so electron-builder can package @cypress/request dependencies\n- document the correct download-site asset alias for GUI releases\n\n## Tests\n- npm test -- tests/fact-store-recovery.test.js tests/first-run.test.js\n- full npm test passed before packaging: 337 files / 2596 tests\n- npm run typecheck\n- build:cli / build:server / build:main / build:renderer\n- macOS arm64 + x64 DMGs signed, notarized, stapled, Gatekeeper accepted\n- Windows Setup built and signed\n\n## Release\n- v0.82.0 Release assets replaced for macOS arm64, macOS x64, Windows, latest-mac.yml, latest.yml\n- mirror public URLs verified